### PR TITLE
RDSモジュールの構築

### DIFF
--- a/terraform/environments/production/.terraform.lock.hcl
+++ b/terraform/environments/production/.terraform.lock.hcl
@@ -23,3 +23,23 @@ provider "registry.terraform.io/hashicorp/aws" {
     "zh:f142320e9d4a5c663f6e9924abe05274bbbc4031700bac3387e0a67ec6c951ef",
   ]
 }
+
+provider "registry.terraform.io/hashicorp/random" {
+  version     = "3.7.2"
+  constraints = "~> 3.0"
+  hashes = [
+    "h1:KG4NuIBl1mRWU0KD/BGfCi1YN/j3F7H4YgeeM7iSdNs=",
+    "zh:14829603a32e4bc4d05062f059e545a91e27ff033756b48afbae6b3c835f508f",
+    "zh:1527fb07d9fea400d70e9e6eb4a2b918d5060d604749b6f1c361518e7da546dc",
+    "zh:1e86bcd7ebec85ba336b423ba1db046aeaa3c0e5f921039b3f1a6fc2f978feab",
+    "zh:24536dec8bde66753f4b4030b8f3ef43c196d69cccbea1c382d01b222478c7a3",
+    "zh:29f1786486759fad9b0ce4fdfbbfece9343ad47cd50119045075e05afe49d212",
+    "zh:4d701e978c2dd8604ba1ce962b047607701e65c078cb22e97171513e9e57491f",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7b8434212eef0f8c83f5a90c6d76feaf850f6502b61b53c329e85b3b281cba34",
+    "zh:ac8a23c212258b7976e1621275e3af7099e7e4a3d4478cf8d5d2a27f3bc3e967",
+    "zh:b516ca74431f3df4c6cf90ddcdb4042c626e026317a33c53f0b445a3d93b720d",
+    "zh:dc76e4326aec2490c1600d6871a95e78f9050f9ce427c71707ea412a2f2f1a62",
+    "zh:eac7b63e86c749c7d48f527671c7aee5b4e26c10be6ad7232d6860167f99dbb0",
+  ]
+}

--- a/terraform/environments/production/main.tf
+++ b/terraform/environments/production/main.tf
@@ -6,6 +6,10 @@ terraform {
       source  = "hashicorp/aws"
       version = "~> 6.0"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
   }
 }
 
@@ -57,4 +61,17 @@ module "ecr" {
   project_name           = var.project_name
   environment            = var.environment
   image_retention_count  = 5
+}
+
+module "rds" {
+  source = "../../modules/rds"
+
+  project_name           = var.project_name
+  environment            = var.environment
+  vpc_id                 = module.networking.vpc_id
+  private_subnet_ids     = [
+    module.networking.private_subnet_1_id,
+    module.networking.private_subnet_2_id
+  ]
+  rds_security_group_id  = module.security.rds_security_group_id
 }

--- a/terraform/environments/production/outputs.tf
+++ b/terraform/environments/production/outputs.tf
@@ -87,3 +87,23 @@ output "backend_ecr_repository_url" {
   description = "BackendのECRリポジトリURL"
   value       = module.ecr.backend_repository_url
 }
+
+output "db_instance_endpoint" {
+  description = "RDSインスタンスのエンドポイント"
+  value       = module.rds.db_instance_endpoint
+}
+
+output "db_instance_address" {
+  description = "RDSインスタンスのアドレス"
+  value       = module.rds.db_instance_address
+}
+
+output "db_name" {
+  description = "データベース名"
+  value       = module.rds.db_name
+}
+
+output "db_password_secret_arn" {
+  description = "データベースパスワードのSecrets Manager ARN"
+  value       = module.rds.db_password_secret_arn
+}

--- a/terraform/modules/rds/main.tf
+++ b/terraform/modules/rds/main.tf
@@ -1,0 +1,45 @@
+resource "aws_db_subnet_group" "main" {
+  name       = "${var.project_name}-${var.environment}-db-subnet-group"
+  subnet_ids = var.private_subnet_ids
+
+  tags = {
+    Name        = "${var.project_name}-db-subnet-group"
+    Environment = var.environment
+  }
+}
+
+resource "aws_db_instance" "main" {
+  identifier = "${var.project_name}-${var.environment}-db"
+
+  engine         = "mysql"
+  engine_version = "8.0"
+  instance_class = var.db_instance_class
+
+  allocated_storage     = var.allocated_storage
+  max_allocated_storage = 0
+  storage_type          = "gp3"
+  storage_encrypted     = true
+
+  db_name  = var.db_name
+  username = var.db_username
+  password = random_password.db_password.result
+
+  db_subnet_group_name   = aws_db_subnet_group.main.name
+  vpc_security_group_ids = [var.rds_security_group_id]
+  parameter_group_name   = aws_db_parameter_group.main.name
+
+  multi_az               = false
+  publicly_accessible    = false
+  deletion_protection    = false
+  skip_final_snapshot    = true
+  backup_retention_period = var.backup_retention_period
+  backup_window          = var.backup_window
+  maintenance_window     = var.maintenance_window
+
+  enabled_cloudwatch_logs_exports = ["error", "general", "slowquery"]
+
+  tags = {
+    Name        = "${var.project_name}-rds"
+    Environment = var.environment
+  }
+}

--- a/terraform/modules/rds/outputs.tf
+++ b/terraform/modules/rds/outputs.tf
@@ -1,0 +1,39 @@
+output "db_instance_endpoint" {
+  description = "RDSインスタンスのエンドポイント"
+  value       = aws_db_instance.main.endpoint
+}
+
+output "db_instance_address" {
+  description = "RDSインスタンスのアドレス"
+  value       = aws_db_instance.main.address
+}
+
+output "db_instance_port" {
+  description = "RDSインスタンスのポート"
+  value       = aws_db_instance.main.port
+}
+
+output "db_instance_arn" {
+  description = "RDSインスタンスのARN"
+  value       = aws_db_instance.main.arn
+}
+
+output "db_name" {
+  description = "データベース名"
+  value       = aws_db_instance.main.db_name
+}
+
+output "db_username" {
+  description = "データベースユーザー名"
+  value       = aws_db_instance.main.username
+}
+
+output "db_password_secret_arn" {
+  description = "データベースパスワードのSecrets Manager ARN"
+  value       = aws_secretsmanager_secret.db_password.arn
+}
+
+output "db_password_secret_name" {
+  description = "データベースパスワードのSecrets Manager名"
+  value       = aws_secretsmanager_secret.db_password.name
+}

--- a/terraform/modules/rds/parameter_group.tf
+++ b/terraform/modules/rds/parameter_group.tf
@@ -1,0 +1,49 @@
+resource "aws_db_parameter_group" "main" {
+  name   = "${var.project_name}-${var.environment}-mysql80"
+  family = "mysql8.0"
+
+  parameter {
+    name  = "character_set_client"
+    value = "utf8mb4"
+  }
+
+  parameter {
+    name  = "character_set_connection"
+    value = "utf8mb4"
+  }
+
+  parameter {
+    name  = "character_set_database"
+    value = "utf8mb4"
+  }
+
+  parameter {
+    name  = "character_set_results"
+    value = "utf8mb4"
+  }
+
+  parameter {
+    name  = "character_set_server"
+    value = "utf8mb4"
+  }
+
+  parameter {
+    name  = "collation_connection"
+    value = "utf8mb4_unicode_ci"
+  }
+
+  parameter {
+    name  = "collation_server"
+    value = "utf8mb4_unicode_ci"
+  }
+
+  parameter {
+    name  = "time_zone"
+    value = "Asia/Tokyo"
+  }
+
+  tags = {
+    Name        = "${var.project_name}-parameter-group"
+    Environment = var.environment
+  }
+}

--- a/terraform/modules/rds/secrets.tf
+++ b/terraform/modules/rds/secrets.tf
@@ -1,0 +1,20 @@
+resource "random_password" "db_password" {
+  length           = 32
+  special          = true
+  override_special = "!#$%^&*()-_=+[]{}?"
+}
+
+resource "aws_secretsmanager_secret" "db_password" {
+  name                    = "${var.project_name}-${var.environment}-db-password"
+  recovery_window_in_days = 0
+
+  tags = {
+    Name        = "${var.project_name}-db-password"
+    Environment = var.environment
+  }
+}
+
+resource "aws_secretsmanager_secret_version" "db_password" {
+  secret_id     = aws_secretsmanager_secret.db_password.id
+  secret_string = random_password.db_password.result
+}

--- a/terraform/modules/rds/variables.tf
+++ b/terraform/modules/rds/variables.tf
@@ -1,0 +1,66 @@
+variable "project_name" {
+  description = "プロジェクト名"
+  type        = string
+}
+
+variable "environment" {
+  description = "環境名（production/staging/development）"
+  type        = string
+}
+
+variable "vpc_id" {
+  description = "VPCのID"
+  type        = string
+}
+
+variable "private_subnet_ids" {
+  description = "プライベートサブネットのIDリスト（最低2つ必要）"
+  type        = list(string)
+}
+
+variable "rds_security_group_id" {
+  description = "RDS用セキュリティグループのID"
+  type        = string
+}
+
+variable "db_name" {
+  description = "データベース名"
+  type        = string
+  default     = "dragons_counter"
+}
+
+variable "db_username" {
+  description = "データベースユーザー名"
+  type        = string
+  default     = "admin"
+}
+
+variable "db_instance_class" {
+  description = "RDSインスタンスクラス"
+  type        = string
+  default     = "db.t4g.micro"
+}
+
+variable "allocated_storage" {
+  description = "割り当てストレージ容量（GB）"
+  type        = number
+  default     = 20
+}
+
+variable "backup_retention_period" {
+  description = "バックアップ保持期間（日数）"
+  type        = number
+  default     = 7
+}
+
+variable "backup_window" {
+  description = "バックアップウィンドウ（UTC）"
+  type        = string
+  default     = "17:00-18:00"
+}
+
+variable "maintenance_window" {
+  description = "メンテナンスウィンドウ（UTC）"
+  type        = string
+  default     = "sun:18:00-sun:19:00"
+}


### PR DESCRIPTION
close #5 
close #7 

## Summary
- RDS MySQL 8.0インスタンスの構築
- Secrets Managerによるパスワード管理
- DB Subnet GroupとParameter Groupの設定

## 実装内容

### RDSインスタンス
- **エンジン**: MySQL 8.0
- **インスタンスクラス**: db.t4g.micro（コスト最適化）
- **ストレージ**: 20GB gp3、暗号化有効
- **自動拡張**: 無効
- **マルチAZ**: 無効
- **削除保護**: 無効
- **配置**: プライベートサブネット（ECSと同一サブネット）

### セキュリティ
- プライベートサブネット配置（インターネット非公開）
- RDS Security Group（ECSからのみアクセス許可）
- Secrets Managerでパスワード管理（32文字ランダム生成）
- パブリックアクセス無効

### バックアップ
- 保持期間: 7日間
- バックアップウィンドウ: 17:00-18:00 UTC（日本時間 02:00-03:00）
- メンテナンスウィンドウ: 日曜 18:00-19:00 UTC（日本時間 日曜 03:00-04:00）

### DB Parameter Group
- 文字コード: utf8mb4
- 照合順序: utf8mb4_unicode_ci
- タイムゾーン: Asia/Tokyo

### CloudWatch Logs
- エラーログ、一般ログ、スロークエリログを出力

## ファイル構成

```
terraform/modules/rds/
├── main.tf              # RDSインスタンス + DB Subnet Group
├── secrets.tf           # Secrets Manager + ランダムパスワード生成
├── parameter_group.tf   # MySQL 8.0パラメータグループ
├── variables.tf         # 変数定義
└── outputs.tf           # エンドポイント、ARN等の出力
```

## 技術的な修正

- `random_password`で生成するパスワードにRDS禁止文字（`/@"` スペース）を除外
- `override_special = "!#$%^&*()-_=+[]{}?"` で許可文字のみ使用

## コスト見積もり

- RDS db.t4g.micro: 無料枠なら$0、超過後$13/月
- ストレージ 20GB gp3: $2.3/月
- バックアップストレージ: 20GBまで無料
- Secrets Manager: $0.40/月

**合計**: 約$15-16/月（無料枠外の場合）

## Test plan
- [x] Terraform実装完了
- [x] terraform init で randomプロバイダー追加確認
- [x] terraform plan で構文エラーなし確認
- [x] terraform apply でRDS作成成功確認
- [x] パスワード生成でRDS禁止文字除外確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)