### PR TITLE
CodeDeployエージェントのインストール方法を公式リファレンスに準拠

### DIFF
--- a/terraform/modules/ec2/user_data.sh
+++ b/terraform/modules/ec2/user_data.sh
@@ -23,27 +23,11 @@ dnf install -y ruby wget
 cd /home/ec2-user
 wget https://aws-codedeploy-${aws_region}.s3.${aws_region}.amazonaws.com/latest/install
 chmod +x ./install
-./install
+sudo ./install auto
 
-cat > /etc/systemd/system/codedeploy-agent.service << 'CODEDEPLOYEOF'
-[Unit]
-Description=AWS CodeDeploy Host Agent
-After=network-online.target
-
-[Service]
-Type=simple
-ExecStart=/opt/codedeploy-agent/bin/codedeploy-agent start
-KillMode=process
-Restart=on-failure
-RestartSec=30
-
-[Install]
-WantedBy=multi-user.target
-CODEDEPLOYEOF
-
-systemctl daemon-reload
-systemctl enable codedeploy-agent
+systemctl status codedeploy-agent
 systemctl start codedeploy-agent
+systemctl status codedeploy-agent
 echo "CodeDeploy agent installed and started"
 
 mkdir -p /opt/dragons-counter


### PR DESCRIPTION
## Summary
- Amazon Linux 2023でのCodeDeployエージェントインストール問題を修正
- `sudo ./install auto`で標準インストールを実行
- 手動のsystemd unitファイル作成を削除し、公式の方法に準拠

## 変更内容
- `./install` → `sudo ./install auto` に変更
- 不要なsystemd unitファイル作成処理を削除
- `systemctl status`でエージェント状態確認を追加

## 背景
Amazon Linux 2023でCodeDeployエージェントをインストールする際、手動でsystemd unitファイルを作成する方法ではエージェントが正しく動作しなかったため、公式リファレンスに準拠した方法に変更。

## Test plan
- [x] terraform applyでEC2を再作成
- [x] CodeDeployエージェントが正常起動することを確認
- [x] アプリケーションコンテナが正常起動することを確認
- [ ] mainマージ後にCodeDeployが自動実行されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)