### PR TITLE
#37 ローカルファイル保存時のLint設定をCIと統一

### DIFF
--- a/frontend/.prettierrc
+++ b/frontend/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "semi": true,
+  "singleQuote": false,
+  "tabWidth": 2,
+  "trailingComma": "all",
+  "printWidth": 80
+}

--- a/frontend/.vscode/settings.json
+++ b/frontend/.vscode/settings.json
@@ -1,0 +1,22 @@
+{
+  "editor.formatOnSave": true,
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "[typescript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[typescriptreact]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[javascript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[javascriptreact]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[json]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[css]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  }
+}


### PR DESCRIPTION
## Summary

- `.prettierrc` を追加してPrettier設定を明示化（trailingComma: "all" 等）
- `.vscode/settings.json` を追加してファイル保存時に自動フォーマットを有効化

## Test plan

- [ ] VSCodeでPrettier拡張機能をインストール
- [ ] frontendディレクトリを開いてファイルを保存
- [ ] 保存時にtrailingCommaが削除されないことを確認
- [ ] `npm run format:check` が通ることを確認

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)