### PR TITLE
#22 ローカル環境のドメイン名をlocal.dravincit.comに変更

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,6 +87,19 @@ services:
     networks:
       - dragons-network
 
+  proxy:
+    image: nginx:1.29.4-alpine
+    ports:
+      - "443:443"
+    volumes:
+      - ./nginx.conf:/etc/nginx/conf.d/default.conf:ro
+      - ./certs:/etc/nginx/certs:ro
+    depends_on:
+      - backend
+      - frontend
+    networks:
+      - dragons-network
+
 networks:
   dragons-network:
     driver: bridge

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,28 @@
+server {
+    listen 443 ssl;
+    server_name local.dravincit.com;
+
+    ssl_certificate /etc/nginx/certs/localhost.pem;
+    ssl_certificate_key /etc/nginx/certs/localhost-key.pem;
+
+    location /api/ {
+        proxy_pass https://backend:3443;
+        proxy_ssl_verify off;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location / {
+        proxy_pass https://frontend:3043;
+        proxy_ssl_verify off;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+    }
+}


### PR DESCRIPTION
## Summary
- ローカル開発環境で `https://local.dravincit.com` でアクセスできるようにリバースプロキシを追加
- nginx をリバースプロキシとして設定し、フロントエンド・バックエンドへのルーティングを実現
- ポート番号なしでアクセス可能に

## Test plan
- [ ] 証明書を `local.dravincit.com` を含めて再発行
- [ ] `/etc/hosts` に `127.0.0.1 local.dravincit.com` を追加
- [ ] `.env` の `ALLOWED_ORIGINS` と `VITE_API_URL` を更新
- [ ] `docker compose up -d` で起動
- [ ] `https://local.dravincit.com` でフロントエンドにアクセスできることを確認
- [ ] API (`/api/*`) が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)