### PR TITLE
feat: Users/UserRegistrationRequestテーブルのスキーマを追加

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -45,3 +45,33 @@ model Stadium {
 
   @@map("stadiums")
 }
+
+model User {
+  id                   String                    @id @default(uuid())
+  email                String                    @unique
+  password             String                    @map("password")
+  registrationRequests UserRegistrationRequest[]
+  createdAt            DateTime                  @default(now()) @map("created_at")
+  updatedAt            DateTime                  @updatedAt @map("updated_at")
+
+  @@map("users")
+}
+
+model UserRegistrationRequest {
+  id                 String             @id @default(uuid())
+  userId             String             @map("user_id")
+  user               User               @relation(fields: [userId], references: [id])
+  status             RegistrationStatus @default(PENDING)
+  reasonForRejection String?
+  createdAt          DateTime           @default(now()) @map("created_at")
+  updatedAt          DateTime           @updatedAt @map("updated_at")
+
+  @@map("user_registration_requests")
+}
+
+enum RegistrationStatus {
+  PENDING  @map("pending")
+  APPROVED @map("approved")
+  REJECTED @map("rejected")
+  BANNED   @map("banned")
+}


### PR DESCRIPTION
## Summary

- ユーザー認証基盤に必要なデータベーススキーマを追加
- ユーザー登録申請状況を履歴管理できる構造を採用

## Changes

### Prisma Schema

**Userモデル**
- `id`: UUID (PK)
- `email`: String (UNIQUE)
- `password`: String
- `registrationRequests`: UserRegistrationRequest[] (1対多)
- `createdAt`, `updatedAt`: DateTime

**UserRegistrationRequestモデル**
- `id`: UUID (PK)
- `userId`: String (FK)
- `status`: RegistrationStatus enum
- `reasonForRejection`: String? (拒否理由)
- `createdAt`, `updatedAt`: DateTime

**RegistrationStatus enum**
- `PENDING` - 申請中
- `APPROVED` - 承認済み
- `REJECTED` - 拒否
- `BANNED` - 利用停止

## Design Decision

ユーザーステータスを別テーブル（UserRegistrationRequest）で管理することで：
- 登録申請状況の履歴を保持
- 将来的なban機能（期間管理等）に対応可能

## Related Issue

Related to #84

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ユーザーアカウント登録システムの基盤を追加しました
  * ユーザー登録リクエストの管理・承認フローを実装しました
  * 登録ステータス（保留中、承認、却下、バン）の追跡機能を追加しました

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->