### PR TITLE
JwtAuthGuardの作成

### DIFF
--- a/backend/src/application/auth/guards/jwt-auth.guard.spec.ts
+++ b/backend/src/application/auth/guards/jwt-auth.guard.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { JwtAuthGuard } from './jwt-auth.guard';
+
+describe('JwtAuthGuard', () => {
+  let guard: JwtAuthGuard;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [JwtAuthGuard],
+    }).compile();
+
+    guard = module.get<JwtAuthGuard>(JwtAuthGuard);
+  });
+
+  it('JwtAuthGuardのインスタンスが正しく生成される', () => {
+    expect(guard).toBeDefined();
+  });
+});

--- a/backend/src/application/auth/guards/jwt-auth.guard.ts
+++ b/backend/src/application/auth/guards/jwt-auth.guard.ts
@@ -1,0 +1,5 @@
+import { Injectable } from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+
+@Injectable()
+export class JwtAuthGuard extends AuthGuard('jwt') {}


### PR DESCRIPTION
## 概要

JWT認証によるエンドポイント保護のため、NestJSのAuthGuard('jwt')を継承したJwtAuthGuardを作成した。

Closes #93

## 変更内容

- `backend/src/application/auth/guards/jwt-auth.guard.ts` を新規作成（AuthGuard('jwt')を継承したJWT認証ガードクラス）
- `backend/src/application/auth/guards/jwt-auth.guard.spec.ts` を新規作成（インスタンス生成の単体テスト）

## テスト

- 単体テストを追加・実行済み（全29スイート、225テストがパス）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **テスト**
  * JWT認証ガードのユニットテストスイートを新規追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->