### PR TITLE
RegistrationStatus.fromPrismaの戻り値型を修正

### DIFF
--- a/backend/src/domain/enums/registration-status.ts
+++ b/backend/src/domain/enums/registration-status.ts
@@ -16,13 +16,13 @@ export const RegistrationStatus = {
     return mapping[status];
   },
 
-  fromPrisma(prismaStatus: PrismaRegistrationStatus): string {
-    const mapping: Record<PrismaRegistrationStatus, string> = {
+  fromPrisma(prismaStatus: PrismaRegistrationStatus) {
+    const mapping = {
       [PrismaRegistrationStatus.PENDING]: 'PENDING',
       [PrismaRegistrationStatus.APPROVED]: 'APPROVED',
       [PrismaRegistrationStatus.REJECTED]: 'REJECTED',
       [PrismaRegistrationStatus.BANNED]: 'BANNED',
-    };
+    } as const;
     return mapping[prismaStatus];
   },
 } as const;


### PR DESCRIPTION
## 概要

`RegistrationStatus.fromPrisma` メソッドの戻り値型指定ミスによるコンパイルエラーを修正しました。

## 変更内容

- `fromPrisma` の明示的な戻り値型 `: string` を削除し、`as const` によるリテラル型推論に変更
- mapping オブジェクトの型を `Record<PrismaRegistrationStatus, string>` から `as const` アサーションに変更

これにより、戻り値が `string` ではなくリテラルユニオン型として正しく推論され、コンパイルエラーが解消されます。

## テスト

既存テストで動作確認済み。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * 登録ステータス処理の内部実装を最適化しました。ユーザーに影響する機能変更はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->