### PR TITLE
ログイン/会員登録ページのルーティング分離

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "lucide-react": "^0.541.0",
         "react": "^19.2.3",
-        "react-dom": "^19.2.3"
+        "react-dom": "^19.2.3",
+        "react-router-dom": "^7.13.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.17.0",
@@ -1957,6 +1958,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -2784,6 +2798,44 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.13.0.tgz",
+      "integrity": "sha512-PZgus8ETambRT17BUm/LL8lX3Of+oiLaPuVTRH3l1eLvSPpKO3AvhAEb5N7ihAFZQrYDqkvvWfFh9p0z9VsjLw==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.13.0.tgz",
+      "integrity": "sha512-5CO/l5Yahi2SKC6rGZ+HDEjpjkGaG/ncEP7eWFTvFxbHP8yeeI0PxTDjimtpXYlR3b3i9/WIL4VJttPrESIf2g==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.13.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -2854,6 +2906,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,7 +15,8 @@
   "dependencies": {
     "lucide-react": "^0.541.0",
     "react": "^19.2.3",
-    "react-dom": "^19.2.3"
+    "react-dom": "^19.2.3",
+    "react-router-dom": "^7.13.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.17.0",

--- a/frontend/src/App.module.css
+++ b/frontend/src/App.module.css
@@ -1,8 +1,0 @@
-.loading {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  min-height: 100vh;
-  font-size: 1.125rem;
-  color: var(--text-secondary);
-}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,35 +1,28 @@
-import { useState } from "react";
+import { BrowserRouter, Routes, Route } from "react-router-dom";
 import { AuthProvider } from "@/contexts/auth-context";
-import { useAuth } from "@/hooks/use-auth";
-import GameList from "@/components/GameList";
-import LoginForm from "@/components/LoginForm";
-import SignupForm from "@/components/SignupForm";
-import styles from "./App.module.css";
-
-function AppContent() {
-  const { isAuthenticated, isLoading, signout } = useAuth();
-  const [authMode, setAuthMode] = useState<"login" | "signup">("login");
-
-  if (isLoading) {
-    return <div className={styles.loading}>読み込み中...</div>;
-  }
-
-  if (!isAuthenticated) {
-    return authMode === "login" ? (
-      <LoginForm onSwitchToSignup={() => setAuthMode("signup")} />
-    ) : (
-      <SignupForm onSwitchToLogin={() => setAuthMode("login")} />
-    );
-  }
-
-  return <GameList onSignout={signout} />;
-}
+import ProtectedRoute from "@/components/ProtectedRoute";
+import LoginPage from "@/pages/LoginPage";
+import SignupPage from "@/pages/SignupPage";
+import HomePage from "@/pages/HomePage";
 
 function App() {
   return (
-    <AuthProvider>
-      <AppContent />
-    </AuthProvider>
+    <BrowserRouter>
+      <AuthProvider>
+        <Routes>
+          <Route path="/login" element={<LoginPage />} />
+          <Route path="/signup" element={<SignupPage />} />
+          <Route
+            path="/"
+            element={
+              <ProtectedRoute>
+                <HomePage />
+              </ProtectedRoute>
+            }
+          />
+        </Routes>
+      </AuthProvider>
+    </BrowserRouter>
   );
 }
 

--- a/frontend/src/components/GameList.tsx
+++ b/frontend/src/components/GameList.tsx
@@ -1,17 +1,17 @@
 import { useState, useEffect } from "react";
+import { useNavigate } from "react-router-dom";
 import { Game } from "@/types/game";
 import { fetchGames, deleteGame } from "@/lib/api/games";
+import { useAuth } from "@/hooks/use-auth";
 import { Trash2, LogOut } from "lucide-react";
 import GameScrapePanel from "./GameScrapePanel";
 import DeleteConfirmDialog from "./DeleteConfirmDialog";
 import DeleteResultDialog from "./DeleteResultDialog";
 import styles from "./GameList.module.css";
 
-interface GameListProps {
-  onSignout: () => Promise<void>;
-}
-
-export default function GameList({ onSignout }: GameListProps) {
+export default function GameList() {
+  const navigate = useNavigate();
+  const { signout } = useAuth();
   const [games, setGames] = useState<Game[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -154,9 +154,11 @@ export default function GameList({ onSignout }: GameListProps) {
           <button
             className={styles.signoutButton}
             onClick={() => {
-              onSignout().catch((err: unknown) => {
-                console.error("Failed to sign out:", err);
-              });
+              signout()
+                .then(() => navigate("/login"))
+                .catch((err: unknown) => {
+                  console.error("Failed to sign out:", err);
+                });
             }}
           >
             <LogOut size={18} />

--- a/frontend/src/components/LoginForm.tsx
+++ b/frontend/src/components/LoginForm.tsx
@@ -1,12 +1,10 @@
 import { useState } from "react";
+import { useNavigate } from "react-router-dom";
 import { useAuth } from "@/hooks/use-auth";
 import styles from "./AuthForm.module.css";
 
-interface LoginFormProps {
-  onSwitchToSignup: () => void;
-}
-
-export default function LoginForm({ onSwitchToSignup }: LoginFormProps) {
+export default function LoginForm() {
+  const navigate = useNavigate();
   const { signin } = useAuth();
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
@@ -19,6 +17,7 @@ export default function LoginForm({ onSwitchToSignup }: LoginFormProps) {
     setIsSubmitting(true);
     try {
       await signin({ email, password });
+      navigate("/");
     } catch (err) {
       setError(err instanceof Error ? err.message : "ログインに失敗しました");
     } finally {
@@ -76,7 +75,7 @@ export default function LoginForm({ onSwitchToSignup }: LoginFormProps) {
           <button
             className={styles.switchLink}
             type="button"
-            onClick={onSwitchToSignup}
+            onClick={() => navigate("/signup")}
           >
             会員登録はこちら
           </button>

--- a/frontend/src/components/ProtectedRoute.tsx
+++ b/frontend/src/components/ProtectedRoute.tsx
@@ -1,0 +1,20 @@
+import { Navigate } from "react-router-dom";
+import { useAuth } from "@/hooks/use-auth";
+
+export default function ProtectedRoute({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const { isAuthenticated, isLoading } = useAuth();
+
+  if (isLoading) {
+    return null;
+  }
+
+  if (!isAuthenticated) {
+    return <Navigate to="/login" replace />;
+  }
+
+  return <>{children}</>;
+}

--- a/frontend/src/components/SignupForm.tsx
+++ b/frontend/src/components/SignupForm.tsx
@@ -1,12 +1,10 @@
 import { useState } from "react";
+import { useNavigate } from "react-router-dom";
 import { useAuth } from "@/hooks/use-auth";
 import styles from "./AuthForm.module.css";
 
-interface SignupFormProps {
-  onSwitchToLogin: () => void;
-}
-
-export default function SignupForm({ onSwitchToLogin }: SignupFormProps) {
+export default function SignupForm() {
+  const navigate = useNavigate();
   const { signup, signin } = useAuth();
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
@@ -27,12 +25,13 @@ export default function SignupForm({ onSwitchToLogin }: SignupFormProps) {
 
     try {
       await signin({ email, password });
+      navigate("/");
     } catch {
       setError(
         "アカウントは作成されました。ログイン画面からログインしてください",
       );
       setIsSubmitting(false);
-      onSwitchToLogin();
+      navigate("/login");
       return;
     }
 
@@ -89,7 +88,7 @@ export default function SignupForm({ onSwitchToLogin }: SignupFormProps) {
           <button
             className={styles.switchLink}
             type="button"
-            onClick={onSwitchToLogin}
+            onClick={() => navigate("/login")}
           >
             ログインはこちら
           </button>

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -1,0 +1,5 @@
+import GameList from "@/components/GameList";
+
+export default function HomePage() {
+  return <GameList />;
+}

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -1,0 +1,17 @@
+import { Navigate } from "react-router-dom";
+import { useAuth } from "@/hooks/use-auth";
+import LoginForm from "@/components/LoginForm";
+
+export default function LoginPage() {
+  const { isAuthenticated, isLoading } = useAuth();
+
+  if (isLoading) {
+    return null;
+  }
+
+  if (isAuthenticated) {
+    return <Navigate to="/" replace />;
+  }
+
+  return <LoginForm />;
+}

--- a/frontend/src/pages/SignupPage.tsx
+++ b/frontend/src/pages/SignupPage.tsx
@@ -1,0 +1,17 @@
+import { Navigate } from "react-router-dom";
+import { useAuth } from "@/hooks/use-auth";
+import SignupForm from "@/components/SignupForm";
+
+export default function SignupPage() {
+  const { isAuthenticated, isLoading } = useAuth();
+
+  if (isLoading) {
+    return null;
+  }
+
+  if (isAuthenticated) {
+    return <Navigate to="/" replace />;
+  }
+
+  return <SignupForm />;
+}


### PR DESCRIPTION
## Summary

- react-router-domを導入し、ログイン(`/login`)・会員登録(`/signup`)・ホーム(`/`)を独立したURLエンドポイントに分離
- `ProtectedRoute`コンポーネントによる認証ガードを実装（未認証時は`/login`へリダイレクト）
- 認証済みで`/login`・`/signup`にアクセスした場合は`/`へリダイレクト
- `LoginForm`・`SignupForm`・`GameList`からコールバックPropsを削除し、`useNavigate`による画面遷移に統一

## Test plan

- `docker compose exec frontend npm run lint && docker compose exec frontend npm run typecheck && docker compose exec frontend npm run format:check` を実行し、全て通過することを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)