### PR TITLE
DockerのMySQLバージョンを8.4.8にアップデート

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   db:
-    image: mysql:8.0
+    image: mysql:8.4.8
     restart: always
     env_file:
       - ./.env
@@ -17,7 +17,7 @@ services:
       - dragons-network
 
   test-db:
-    image: mysql:8.0
+    image: mysql:8.4.8
     restart: always
     environment:
       MYSQL_ROOT_PASSWORD: ${TEST_MYSQL_ROOT_PASSWORD}


### PR DESCRIPTION
## 概要

Docker環境で使用しているMySQLイメージのバージョンが古い（8.0）ため、LTS版である8.4.8にアップデートする。開発環境およびテスト環境の両方のdbサービスを対象とする。

Closes #63

## 変更内容

- `docker-compose.yml` の db サービスのMySQLイメージを `mysql:8.0` から `mysql:8.4.8` に変更
- `docker-compose.yml` の test-db サービスのMySQLイメージを `mysql:8.0` から `mysql:8.4.8` に変更

## テスト

- MySQL 8.4.8 コンテナの正常起動を確認済み
- マイグレーションの正常実行を確認済み
- 全426テスト（63スイート）PASSを確認済み
- lint チェック通過済み

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* MySQL データベースイメージをバージョン 8.0 からバージョン 8.4.8 にアップデートしました。本番環境とテスト環境のデータベースサービスの両方に適用されます。より最新で安定的なデータベース環境を実現し、システムの信頼性向上を図るための重要なアップデートです。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->