### PR TITLE
フロントエンド - ユーザー別観戦試合表示への切り替え

### DIFF
--- a/frontend/src/components/GameList.module.css
+++ b/frontend/src/components/GameList.module.css
@@ -101,26 +101,6 @@
   gap: 12px;
 }
 
-.deleteButton {
-  background: transparent;
-  border: none;
-  color: var(--text-secondary);
-  cursor: pointer;
-  padding: 4px;
-  border-radius: 4px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  transition:
-    color 0.2s ease,
-    background-color 0.2s ease;
-}
-
-.deleteButton:hover {
-  color: #ef4444;
-  background-color: rgba(239, 68, 68, 0.1);
-}
-
 .gameDate {
   font-size: 0.875rem;
   color: var(--text-secondary);

--- a/frontend/src/components/GameList.tsx
+++ b/frontend/src/components/GameList.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react";
 import { useNavigate, Link } from "react-router-dom";
-import { UserGame } from "@/types/game";
+import { UserGame, GameResult } from "@/types/game";
 import { fetchUserGames } from "@/lib/api/games";
 import { useAuth } from "@/hooks/use-auth";
 import { LogOut, Settings } from "lucide-react";
@@ -41,7 +41,7 @@ export default function GameList() {
     });
   };
 
-  const getResultBadgeClass = (result: string) => {
+  const getResultBadgeClass = (result: GameResult) => {
     switch (result) {
       case "win":
         return styles.resultWin;
@@ -54,7 +54,7 @@ export default function GameList() {
     }
   };
 
-  const getResultText = (result: string) => {
+  const getResultText = (result: GameResult) => {
     switch (result) {
       case "win":
         return "勝利";

--- a/frontend/src/components/GameList.tsx
+++ b/frontend/src/components/GameList.tsx
@@ -1,25 +1,17 @@
 import { useState, useEffect } from "react";
 import { useNavigate, Link } from "react-router-dom";
-import { Game } from "@/types/game";
-import { fetchGames, deleteGame } from "@/lib/api/games";
+import { UserGame } from "@/types/game";
+import { fetchUserGames } from "@/lib/api/games";
 import { useAuth } from "@/hooks/use-auth";
-import { Trash2, LogOut, Settings } from "lucide-react";
-import DeleteConfirmDialog from "./DeleteConfirmDialog";
-import DeleteResultDialog from "./DeleteResultDialog";
+import { LogOut, Settings } from "lucide-react";
 import styles from "./GameList.module.css";
 
 export default function GameList() {
   const navigate = useNavigate();
   const { user, signout } = useAuth();
-  const [games, setGames] = useState<Game[]>([]);
+  const [games, setGames] = useState<UserGame[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [deleteTargetGame, setDeleteTargetGame] = useState<Game | null>(null);
-  const [deleteResult, setDeleteResult] = useState<{
-    show: boolean;
-    success: boolean;
-    message: string;
-  }>({ show: false, success: false, message: "" });
 
   useEffect(() => {
     loadGames();
@@ -29,7 +21,7 @@ export default function GameList() {
     try {
       setLoading(true);
       setError(null);
-      const games = await fetchGames();
+      const games = await fetchUserGames();
       setGames(games || []);
     } catch (err) {
       setError("試合データの取得に失敗しました");
@@ -37,49 +29,6 @@ export default function GameList() {
     } finally {
       setLoading(false);
     }
-  };
-
-  const handleDeleteClick = (game: Game) => {
-    setDeleteTargetGame(game);
-  };
-
-  const handleDeleteConfirm = async () => {
-    if (!deleteTargetGame) return;
-
-    try {
-      await deleteGame(deleteTargetGame.id);
-
-      setGames((prevGames) =>
-        prevGames.filter((game) => game.id !== deleteTargetGame.id),
-      );
-
-      setDeleteResult({
-        show: true,
-        success: true,
-        message: "試合記録を削除しました",
-      });
-
-      setDeleteTargetGame(null);
-    } catch (error) {
-      const errorMessage =
-        error instanceof Error
-          ? error.message
-          : "削除中に予期しないエラーが発生しました";
-
-      setDeleteResult({
-        show: true,
-        success: false,
-        message: errorMessage,
-      });
-
-      setDeleteTargetGame(null);
-
-      await loadGames();
-    }
-  };
-
-  const handleDeleteCancel = () => {
-    setDeleteTargetGame(null);
   };
 
   const formatDate = (dateString: string) => {
@@ -94,11 +43,11 @@ export default function GameList() {
 
   const getResultBadgeClass = (result: string) => {
     switch (result) {
-      case "WIN":
+      case "win":
         return styles.resultWin;
-      case "LOSE":
+      case "lose":
         return styles.resultLose;
-      case "DRAW":
+      case "draw":
         return styles.resultDraw;
       default:
         return "";
@@ -214,13 +163,6 @@ export default function GameList() {
                     >
                       {getResultText(game.result)}
                     </span>
-                    <button
-                      className={styles.deleteButton}
-                      onClick={() => handleDeleteClick(game)}
-                      aria-label="delete_game"
-                    >
-                      <Trash2 size={18} />
-                    </button>
                   </div>
                 </div>
                 <div className={styles.gameContent}>
@@ -230,7 +172,9 @@ export default function GameList() {
                   </div>
                   <div className={styles.stadium}>📍 {game.stadium}</div>
                 </div>
-                {game.notes && <div className={styles.notes}>{game.notes}</div>}
+                {game.impression && (
+                  <div className={styles.notes}>{game.impression}</div>
+                )}
               </div>
             ))}
           </div>
@@ -244,21 +188,6 @@ export default function GameList() {
           <button className={styles.addButton}>観戦記録を追加</button>
         </div>
       )}
-
-      <DeleteConfirmDialog
-        isOpen={!!deleteTargetGame}
-        onConfirm={handleDeleteConfirm}
-        onCancel={handleDeleteCancel}
-        opponent={deleteTargetGame?.opponent || ""}
-        gameDate={deleteTargetGame?.gameDate || ""}
-      />
-
-      <DeleteResultDialog
-        isOpen={deleteResult.show}
-        isSuccess={deleteResult.success}
-        message={deleteResult.message}
-        onClose={() => setDeleteResult({ ...deleteResult, show: false })}
-      />
     </div>
   );
 }

--- a/frontend/src/lib/api/games.ts
+++ b/frontend/src/lib/api/games.ts
@@ -1,4 +1,4 @@
-import { Game } from "@/types/game";
+import { Game, UserGame } from "@/types/game";
 import { getCsrfToken } from "../csrf";
 
 const API_BASE_URL = import.meta.env.VITE_API_URL;
@@ -17,6 +17,26 @@ export async function fetchGames(): Promise<Game[]> {
   if (!response.ok) {
     throw new Error(
       "レスポンス取得で予期しないエラーが発生しました。しばらく経ってから再度お試しください",
+    );
+  }
+
+  return response.json();
+}
+
+export async function fetchUserGames(): Promise<UserGame[]> {
+  if (!API_BASE_URL) {
+    throw new Error(
+      "予期しないエラーが発生しました。しばらく経ってから再度お試しください",
+    );
+  }
+
+  const response = await fetch(`${API_BASE_URL}/user-games`, {
+    credentials: "include",
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      "観戦記録の取得に失敗しました。しばらく経ってから再度お試しください",
     );
   }
 

--- a/frontend/src/types/game.ts
+++ b/frontend/src/types/game.ts
@@ -13,6 +13,20 @@ export interface Game {
   updatedAt: string;
 }
 
+export interface UserGame {
+  id: string;
+  gameId: string;
+  gameDate: string;
+  opponent: string;
+  dragonsScore: number;
+  opponentScore: number;
+  result: GameResult;
+  stadium: string;
+  impression: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
 export interface GetGamesResponse {
   games: Game[];
   total: number;


### PR DESCRIPTION
## Summary

- `UserGame`型定義を追加し、バックエンドの`UserGameResponseDto`に対応
- `fetchUserGames()` API関数を追加（`GET /user-games`エンドポイント呼び出し）
- `GameList`コンポーネントのデータ取得を`fetchGames()`から`fetchUserGames()`に切り替え
- `getResultBadgeClass`の大文字比較バグを修正（`"WIN"` → `"win"`に統一）
- `notes`表示を`impression`に変更
- 削除機能を一時的に除去（別Issue対応予定）
- 未使用CSS（`.deleteButton`）を削除

## Test plan

- [ ] `npm run typecheck` が成功すること
- [ ] `npm run lint` がエラーなしで通ること
- [ ] `npm run format:check` が通ること
- [ ] ホームページでユーザー別観戦試合が表示されること
- [ ] 結果バッジの色が正しく適用されること（勝利: 緑、敗北: 赤、引き分け: グレー）
- [ ] 統計情報（勝敗数・勝率）が正しく表示されること

Closes #156

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# リリースノート

* **削除**
  * ゲームリストから削除ボタンを削除しました。削除確認ダイアログも表示されなくなります。

* **UI の更新**
  * ゲーム情報の表示フィールドを「メモ」から「印象」に変更しました。

* **改善**
  * ゲームデータの取得処理を最適化し、ページネーション機能に対応しました。エラーハンドリングを強化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->