### PR TITLE
ユーザー試合観戦登録のフロントエンド実装

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ certs/
 .claude/*.log
 .claude/audit-*.log
 .claude/tmp/
+.claude/worktrees/
 **/.terraform/*
 *.tfstate
 *.tfstate.*

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -2731,6 +2731,19 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -3007,19 +3020,6 @@
         }
       }
     },
-    "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/ts-api-utils": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
@@ -3223,19 +3223,6 @@
         "picomatch": {
           "optional": true
         }
-      }
-    },
-    "node_modules/vite/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/vite/node_modules/postcss": {

--- a/frontend/src/components/GameList.module.css
+++ b/frontend/src/components/GameList.module.css
@@ -212,7 +212,16 @@
   margin-bottom: 24px;
 }
 
+.addButtonWrapper {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: 24px;
+}
+
 .addButton {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
   background: var(--primary);
   color: white;
   border: none;

--- a/frontend/src/components/GameList.tsx
+++ b/frontend/src/components/GameList.tsx
@@ -1,85 +1,34 @@
 import { useState, useEffect } from "react";
 import { useNavigate, Link } from "react-router-dom";
-import { Game } from "@/types/game";
-import { fetchGames, deleteGame } from "@/lib/api/games";
+import { UserGame } from "@/types/user-game";
+import { fetchUserGames } from "@/lib/api/user-games";
 import { useAuth } from "@/hooks/use-auth";
-import { Trash2, LogOut, Settings } from "lucide-react";
-import DeleteConfirmDialog from "./DeleteConfirmDialog";
-import DeleteResultDialog from "./DeleteResultDialog";
+import { LogOut, Settings } from "lucide-react";
 import styles from "./GameList.module.css";
 
 export default function GameList() {
   const navigate = useNavigate();
   const { user, signout } = useAuth();
-  const [games, setGames] = useState<Game[]>([]);
+  const [games, setGames] = useState<UserGame[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [deleteTargetGame, setDeleteTargetGame] = useState<Game | null>(null);
-  const [deleteResult, setDeleteResult] = useState<{
-    show: boolean;
-    success: boolean;
-    message: string;
-  }>({ show: false, success: false, message: "" });
 
   useEffect(() => {
-    loadGames();
+    loadUserGames();
   }, []);
 
-  const loadGames = async () => {
+  const loadUserGames = async () => {
     try {
       setLoading(true);
       setError(null);
-      const games = await fetchGames();
-      setGames(games || []);
+      const userGames = await fetchUserGames();
+      setGames(userGames || []);
     } catch (err) {
       setError("試合データの取得に失敗しました");
-      console.error("Failed to fetch games:", err);
+      console.error("Failed to fetch user games:", err);
     } finally {
       setLoading(false);
     }
-  };
-
-  const handleDeleteClick = (game: Game) => {
-    setDeleteTargetGame(game);
-  };
-
-  const handleDeleteConfirm = async () => {
-    if (!deleteTargetGame) return;
-
-    try {
-      await deleteGame(deleteTargetGame.id);
-
-      setGames((prevGames) =>
-        prevGames.filter((game) => game.id !== deleteTargetGame.id),
-      );
-
-      setDeleteResult({
-        show: true,
-        success: true,
-        message: "試合記録を削除しました",
-      });
-
-      setDeleteTargetGame(null);
-    } catch (error) {
-      const errorMessage =
-        error instanceof Error
-          ? error.message
-          : "削除中に予期しないエラーが発生しました";
-
-      setDeleteResult({
-        show: true,
-        success: false,
-        message: errorMessage,
-      });
-
-      setDeleteTargetGame(null);
-
-      await loadGames();
-    }
-  };
-
-  const handleDeleteCancel = () => {
-    setDeleteTargetGame(null);
   };
 
   const formatDate = (dateString: string) => {
@@ -94,11 +43,11 @@ export default function GameList() {
 
   const getResultBadgeClass = (result: string) => {
     switch (result) {
-      case "WIN":
+      case "win":
         return styles.resultWin;
-      case "LOSE":
+      case "lose":
         return styles.resultLose;
-      case "DRAW":
+      case "draw":
         return styles.resultDraw;
       default:
         return "";
@@ -208,20 +157,11 @@ export default function GameList() {
                   <span className={styles.gameDate}>
                     {formatDate(game.gameDate)}
                   </span>
-                  <div className={styles.gameHeaderActions}>
-                    <span
-                      className={`${styles.resultBadge} ${getResultBadgeClass(game.result)}`}
-                    >
-                      {getResultText(game.result)}
-                    </span>
-                    <button
-                      className={styles.deleteButton}
-                      onClick={() => handleDeleteClick(game)}
-                      aria-label="delete_game"
-                    >
-                      <Trash2 size={18} />
-                    </button>
-                  </div>
+                  <span
+                    className={`${styles.resultBadge} ${getResultBadgeClass(game.result)}`}
+                  >
+                    {getResultText(game.result)}
+                  </span>
                 </div>
                 <div className={styles.gameContent}>
                   <div className={styles.opponent}>vs {game.opponent}</div>
@@ -243,21 +183,6 @@ export default function GameList() {
           <button className={styles.addButton}>観戦記録を追加</button>
         </div>
       )}
-
-      <DeleteConfirmDialog
-        isOpen={!!deleteTargetGame}
-        onConfirm={handleDeleteConfirm}
-        onCancel={handleDeleteCancel}
-        opponent={deleteTargetGame?.opponent || ""}
-        gameDate={deleteTargetGame?.gameDate || ""}
-      />
-
-      <DeleteResultDialog
-        isOpen={deleteResult.show}
-        isSuccess={deleteResult.success}
-        message={deleteResult.message}
-        onClose={() => setDeleteResult({ ...deleteResult, show: false })}
-      />
     </div>
   );
 }

--- a/frontend/src/components/GameList.tsx
+++ b/frontend/src/components/GameList.tsx
@@ -43,7 +43,6 @@ export default function GameList() {
     await loadUserGames();
   };
 
-
   const calculateStats = () => {
     const wins = games.filter((g) => g.result === "win").length;
     const losses = games.filter((g) => g.result === "lose").length;

--- a/frontend/src/components/GameList.tsx
+++ b/frontend/src/components/GameList.tsx
@@ -2,6 +2,11 @@ import { useState, useEffect } from "react";
 import { useNavigate, Link } from "react-router-dom";
 import { UserGame } from "@/types/user-game";
 import { fetchUserGames, registerUserGame } from "@/lib/api/user-games";
+import {
+  formatGameDate,
+  getResultText,
+  getResultBadgeClass,
+} from "@/lib/game-utils";
 import { useAuth } from "@/hooks/use-auth";
 import { LogOut, Settings, Plus } from "lucide-react";
 import GameSelectModal from "./GameSelectModal";
@@ -38,41 +43,6 @@ export default function GameList() {
     await loadUserGames();
   };
 
-  const formatDate = (dateString: string) => {
-    const date = new Date(dateString);
-    return date.toLocaleDateString("ja-JP", {
-      year: "numeric",
-      month: "long",
-      day: "numeric",
-      weekday: "short",
-    });
-  };
-
-  const getResultBadgeClass = (result: string) => {
-    switch (result) {
-      case "win":
-        return styles.resultWin;
-      case "lose":
-        return styles.resultLose;
-      case "draw":
-        return styles.resultDraw;
-      default:
-        return "";
-    }
-  };
-
-  const getResultText = (result: string) => {
-    switch (result) {
-      case "win":
-        return "勝利";
-      case "lose":
-        return "敗北";
-      case "draw":
-        return "引き分け";
-      default:
-        return result;
-    }
-  };
 
   const calculateStats = () => {
     const wins = games.filter((g) => g.result === "win").length;
@@ -172,10 +142,10 @@ export default function GameList() {
               <div key={game.id} className={styles.gameCard}>
                 <div className={styles.gameHeader}>
                   <span className={styles.gameDate}>
-                    {formatDate(game.gameDate)}
+                    {formatGameDate(game.gameDate)}
                   </span>
                   <span
-                    className={`${styles.resultBadge} ${getResultBadgeClass(game.result)}`}
+                    className={`${styles.resultBadge} ${getResultBadgeClass(game.result, styles)}`}
                   >
                     {getResultText(game.result)}
                   </span>

--- a/frontend/src/components/GameList.tsx
+++ b/frontend/src/components/GameList.tsx
@@ -1,9 +1,10 @@
 import { useState, useEffect } from "react";
 import { useNavigate, Link } from "react-router-dom";
 import { UserGame } from "@/types/user-game";
-import { fetchUserGames } from "@/lib/api/user-games";
+import { fetchUserGames, registerUserGame } from "@/lib/api/user-games";
 import { useAuth } from "@/hooks/use-auth";
-import { LogOut, Settings } from "lucide-react";
+import { LogOut, Settings, Plus } from "lucide-react";
+import GameSelectModal from "./GameSelectModal";
 import styles from "./GameList.module.css";
 
 export default function GameList() {
@@ -12,6 +13,7 @@ export default function GameList() {
   const [games, setGames] = useState<UserGame[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [isModalOpen, setIsModalOpen] = useState(false);
 
   useEffect(() => {
     loadUserGames();
@@ -29,6 +31,11 @@ export default function GameList() {
     } finally {
       setLoading(false);
     }
+  };
+
+  const handleRegister = async (gameId: string) => {
+    await registerUserGame(gameId);
+    await loadUserGames();
   };
 
   const formatDate = (dateString: string) => {
@@ -125,6 +132,16 @@ export default function GameList() {
 
       {games.length > 0 ? (
         <>
+          <div className={styles.addButtonWrapper}>
+            <button
+              className={styles.addButton}
+              onClick={() => setIsModalOpen(true)}
+            >
+              <Plus size={18} />
+              観戦記録を追加
+            </button>
+          </div>
+
           <div className={styles.statsCard}>
             <div className={styles.statsGrid}>
               <div className={styles.statItem}>
@@ -180,9 +197,21 @@ export default function GameList() {
           <p className={styles.emptyStateText}>
             最初の観戦記録を追加して、思い出を記録しましょう
           </p>
-          <button className={styles.addButton}>観戦記録を追加</button>
+          <button
+            className={styles.addButton}
+            onClick={() => setIsModalOpen(true)}
+          >
+            観戦記録を追加
+          </button>
         </div>
       )}
+
+      <GameSelectModal
+        isOpen={isModalOpen}
+        onClose={() => setIsModalOpen(false)}
+        onRegister={handleRegister}
+        registeredGameIds={games.map((game) => game.gameId)}
+      />
     </div>
   );
 }

--- a/frontend/src/components/GameSelectModal.module.css
+++ b/frontend/src/components/GameSelectModal.module.css
@@ -1,0 +1,202 @@
+.overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  animation: fadeIn 0.2s ease;
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+.dialog {
+  background: var(--card-bg);
+  border-radius: 12px;
+  padding: 24px;
+  max-width: 600px;
+  width: 90%;
+  max-height: 80vh;
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 10px 40px rgba(0, 0, 0, 0.2);
+  animation: slideUp 0.3s ease;
+}
+
+@keyframes slideUp {
+  from {
+    transform: translateY(20px);
+    opacity: 0;
+  }
+  to {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 16px;
+  flex-shrink: 0;
+}
+
+.title {
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: var(--foreground);
+}
+
+.closeButton {
+  background: transparent;
+  border: none;
+  color: var(--text-secondary);
+  cursor: pointer;
+  padding: 4px;
+  border-radius: 4px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition:
+    color 0.2s ease,
+    background-color 0.2s ease;
+}
+
+.closeButton:hover {
+  color: var(--foreground);
+  background-color: var(--hover-bg);
+}
+
+.gameList {
+  overflow-y: auto;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.gameItem {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 16px;
+  background: var(--card-bg);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  transition: box-shadow 0.2s ease;
+}
+
+.gameItem:hover {
+  box-shadow: 0 2px 8px var(--shadow);
+}
+
+.gameInfo {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.gameDate {
+  font-size: 0.875rem;
+  color: var(--text-secondary);
+}
+
+.gameOpponent {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--foreground);
+}
+
+.gameDetails {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-size: 0.875rem;
+  color: var(--text-secondary);
+}
+
+.gameScore {
+  font-weight: 600;
+  color: var(--primary);
+}
+
+.resultBadge {
+  padding: 2px 8px;
+  border-radius: 12px;
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+}
+
+.resultWin {
+  background: #10b981;
+  color: white;
+}
+
+.resultLose {
+  background: #ef4444;
+  color: white;
+}
+
+.resultDraw {
+  background: #6b7280;
+  color: white;
+}
+
+.registerButton {
+  background: var(--primary);
+  color: white;
+  border: none;
+  padding: 8px 16px;
+  border-radius: 8px;
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.2s ease;
+  flex-shrink: 0;
+}
+
+.registerButton:hover {
+  background: var(--primary-hover);
+}
+
+.registerButton:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.loading {
+  text-align: center;
+  padding: 40px 20px;
+  font-size: 1rem;
+  color: var(--text-secondary);
+}
+
+.error {
+  text-align: center;
+  padding: 16px;
+  background: #fee;
+  border-radius: 8px;
+  color: #dc2626;
+  font-size: 0.875rem;
+  margin-bottom: 12px;
+}
+
+.empty {
+  text-align: center;
+  padding: 40px 20px;
+  color: var(--text-secondary);
+  font-size: 0.95rem;
+}

--- a/frontend/src/components/GameSelectModal.tsx
+++ b/frontend/src/components/GameSelectModal.tsx
@@ -72,7 +72,6 @@ export default function GameSelectModal({
     }
   };
 
-
   if (!isOpen) return null;
 
   const unregisteredGames = games.filter(

--- a/frontend/src/components/GameSelectModal.tsx
+++ b/frontend/src/components/GameSelectModal.tsx
@@ -72,7 +72,7 @@ export default function GameSelectModal({
       case "lose":
         return "敗北";
       case "draw":
-        return "引分";
+        return "引き分け";
       default:
         return result;
     }

--- a/frontend/src/components/GameSelectModal.tsx
+++ b/frontend/src/components/GameSelectModal.tsx
@@ -87,7 +87,7 @@ export default function GameSelectModal({
           <button
             className={styles.closeButton}
             onClick={onClose}
-            aria-label="close_modal"
+            aria-label="閉じる"
           >
             <X size={20} />
           </button>

--- a/frontend/src/components/GameSelectModal.tsx
+++ b/frontend/src/components/GameSelectModal.tsx
@@ -46,6 +46,18 @@ export default function GameSelectModal({
     }
   }, [isOpen, loadGames]);
 
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        onClose();
+      }
+    };
+    if (isOpen) {
+      document.addEventListener("keydown", handleKeyDown);
+    }
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [isOpen, onClose]);
+
   const handleRegister = async (gameId: string) => {
     try {
       setRegisteringId(gameId);

--- a/frontend/src/components/GameSelectModal.tsx
+++ b/frontend/src/components/GameSelectModal.tsx
@@ -1,0 +1,159 @@
+import { useState, useEffect, useCallback } from "react";
+import { Game } from "@/types/game";
+import { fetchGames } from "@/lib/api/games";
+import { X, MapPin } from "lucide-react";
+import styles from "./GameSelectModal.module.css";
+
+interface GameSelectModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onRegister: (gameId: string) => Promise<void>;
+  registeredGameIds: string[];
+}
+
+export default function GameSelectModal({
+  isOpen,
+  onClose,
+  onRegister,
+  registeredGameIds,
+}: GameSelectModalProps) {
+  const [games, setGames] = useState<Game[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [registeringId, setRegisteringId] = useState<string | null>(null);
+
+  const loadGames = useCallback(async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      const allGames = await fetchGames();
+      setGames(allGames || []);
+    } catch {
+      setError("試合データの取得に失敗しました");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (isOpen) {
+      loadGames();
+    }
+  }, [isOpen, loadGames]);
+
+  const handleRegister = async (gameId: string) => {
+    try {
+      setRegisteringId(gameId);
+      setError(null);
+      await onRegister(gameId);
+      onClose();
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "登録に失敗しました";
+      setError(message);
+    } finally {
+      setRegisteringId(null);
+    }
+  };
+
+  const formatDate = (dateString: string) => {
+    const date = new Date(dateString);
+    return date.toLocaleDateString("ja-JP", {
+      year: "numeric",
+      month: "long",
+      day: "numeric",
+      weekday: "short",
+    });
+  };
+
+  const getResultText = (result: string) => {
+    switch (result) {
+      case "win":
+        return "勝利";
+      case "lose":
+        return "敗北";
+      case "draw":
+        return "引分";
+      default:
+        return result;
+    }
+  };
+
+  const getResultBadgeClass = (result: string) => {
+    switch (result) {
+      case "win":
+        return styles.resultWin;
+      case "lose":
+        return styles.resultLose;
+      case "draw":
+        return styles.resultDraw;
+      default:
+        return "";
+    }
+  };
+
+  if (!isOpen) return null;
+
+  const unregisteredGames = games.filter(
+    (game) => !registeredGameIds.includes(game.id),
+  );
+
+  return (
+    <div className={styles.overlay} onClick={onClose}>
+      <div className={styles.dialog} onClick={(e) => e.stopPropagation()}>
+        <div className={styles.header}>
+          <h3 className={styles.title}>観戦試合を登録</h3>
+          <button
+            className={styles.closeButton}
+            onClick={onClose}
+            aria-label="close_modal"
+          >
+            <X size={20} />
+          </button>
+        </div>
+
+        {error && <div className={styles.error}>{error}</div>}
+
+        {loading ? (
+          <div className={styles.loading}>試合データを読み込み中...</div>
+        ) : unregisteredGames.length === 0 ? (
+          <div className={styles.empty}>登録可能な試合がありません</div>
+        ) : (
+          <div className={styles.gameList}>
+            {unregisteredGames.map((game) => (
+              <div key={game.id} className={styles.gameItem}>
+                <div className={styles.gameInfo}>
+                  <span className={styles.gameDate}>
+                    {formatDate(game.gameDate)}
+                  </span>
+                  <span className={styles.gameOpponent}>
+                    vs {game.opponent}
+                  </span>
+                  <div className={styles.gameDetails}>
+                    <span className={styles.gameScore}>
+                      {game.dragonsScore} - {game.opponentScore}
+                    </span>
+                    <span
+                      className={`${styles.resultBadge} ${getResultBadgeClass(game.result)}`}
+                    >
+                      {getResultText(game.result)}
+                    </span>
+                    <span>
+                      <MapPin size={14} /> {game.stadium}
+                    </span>
+                  </div>
+                </div>
+                <button
+                  className={styles.registerButton}
+                  onClick={() => handleRegister(game.id)}
+                  disabled={registeringId !== null}
+                >
+                  {registeringId === game.id ? "登録中..." : "登録"}
+                </button>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/GameSelectModal.tsx
+++ b/frontend/src/components/GameSelectModal.tsx
@@ -1,6 +1,11 @@
 import { useState, useEffect, useCallback } from "react";
 import { Game } from "@/types/game";
 import { fetchGames } from "@/lib/api/games";
+import {
+  formatGameDate,
+  getResultText,
+  getResultBadgeClass,
+} from "@/lib/game-utils";
 import { X, MapPin } from "lucide-react";
 import styles from "./GameSelectModal.module.css";
 
@@ -55,41 +60,6 @@ export default function GameSelectModal({
     }
   };
 
-  const formatDate = (dateString: string) => {
-    const date = new Date(dateString);
-    return date.toLocaleDateString("ja-JP", {
-      year: "numeric",
-      month: "long",
-      day: "numeric",
-      weekday: "short",
-    });
-  };
-
-  const getResultText = (result: string) => {
-    switch (result) {
-      case "win":
-        return "勝利";
-      case "lose":
-        return "敗北";
-      case "draw":
-        return "引き分け";
-      default:
-        return result;
-    }
-  };
-
-  const getResultBadgeClass = (result: string) => {
-    switch (result) {
-      case "win":
-        return styles.resultWin;
-      case "lose":
-        return styles.resultLose;
-      case "draw":
-        return styles.resultDraw;
-      default:
-        return "";
-    }
-  };
 
   if (!isOpen) return null;
 
@@ -123,7 +93,7 @@ export default function GameSelectModal({
               <div key={game.id} className={styles.gameItem}>
                 <div className={styles.gameInfo}>
                   <span className={styles.gameDate}>
-                    {formatDate(game.gameDate)}
+                    {formatGameDate(game.gameDate)}
                   </span>
                   <span className={styles.gameOpponent}>
                     vs {game.opponent}
@@ -133,7 +103,7 @@ export default function GameSelectModal({
                       {game.dragonsScore} - {game.opponentScore}
                     </span>
                     <span
-                      className={`${styles.resultBadge} ${getResultBadgeClass(game.result)}`}
+                      className={`${styles.resultBadge} ${getResultBadgeClass(game.result, styles)}`}
                     >
                       {getResultText(game.result)}
                     </span>

--- a/frontend/src/lib/api/user-games.ts
+++ b/frontend/src/lib/api/user-games.ts
@@ -1,0 +1,50 @@
+import { UserGame } from "@/types/user-game";
+import { getCsrfToken } from "../csrf";
+
+const API_BASE_URL = import.meta.env.VITE_API_URL;
+
+export async function fetchUserGames(): Promise<UserGame[]> {
+  if (!API_BASE_URL) {
+    throw new Error(
+      "予期しないエラーが発生しました。しばらく経ってから再度お試しください",
+    );
+  }
+
+  const response = await fetch(`${API_BASE_URL}/user-games`, {
+    credentials: "include",
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      "レスポンス取得で予期しないエラーが発生しました。しばらく経ってから再度お試しください",
+    );
+  }
+
+  return response.json();
+}
+
+export async function registerUserGame(gameId: string): Promise<void> {
+  if (!API_BASE_URL) {
+    throw new Error(
+      "予期しないエラーが発生しました。しばらく経ってから再度お試しください",
+    );
+  }
+
+  const csrfToken = getCsrfToken();
+  const response = await fetch(`${API_BASE_URL}/user-games`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      ...(csrfToken ? { "X-CSRF-Token": csrfToken } : {}),
+    },
+    credentials: "include",
+    body: JSON.stringify({ gameId }),
+  });
+
+  if (!response.ok) {
+    if (response.status === 409) {
+      throw new Error("既に登録済みの試合です");
+    }
+    throw new Error("観戦記録の登録に失敗しました");
+  }
+}

--- a/frontend/src/lib/game-utils.ts
+++ b/frontend/src/lib/game-utils.ts
@@ -1,0 +1,36 @@
+import { GameResult } from "@/types/game";
+
+export function formatGameDate(dateString: string): string {
+  const date = new Date(dateString);
+  return date.toLocaleDateString("ja-JP", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+    weekday: "short",
+  });
+}
+
+export function getResultText(result: GameResult): string {
+  switch (result) {
+    case "win":
+      return "勝利";
+    case "lose":
+      return "敗北";
+    case "draw":
+      return "引き分け";
+  }
+}
+
+export function getResultBadgeClass(
+  result: GameResult,
+  styles: Record<string, string>,
+): string {
+  switch (result) {
+    case "win":
+      return styles.resultWin;
+    case "lose":
+      return styles.resultLose;
+    case "draw":
+      return styles.resultDraw;
+  }
+}

--- a/frontend/src/types/user-game.ts
+++ b/frontend/src/types/user-game.ts
@@ -1,0 +1,14 @@
+import { GameResult } from "./game";
+
+export interface UserGame {
+  id: string;
+  gameId: string;
+  gameDate: string;
+  opponent: string;
+  dragonsScore: number;
+  opponentScore: number;
+  result: GameResult;
+  stadium: string;
+  impression: string | null;
+  createdAt: string;
+}


### PR DESCRIPTION
## 概要

ユーザーのホーム画面に試合マスタから観戦試合を選択・登録するUIを実装し、観戦試合一覧の表示を`users_games`ベースに変更しました。

Closes #164

## 変更内容

- `UserGame`型定義と`user-games` API関数を新規追加（取得・登録・削除）
- `GameList`コンポーネントのデータソースを全試合一覧からuser-games APIに変更
- 試合選択モーダル（`GameSelectModal`）を新規作成し、観戦登録ボタンから呼び出し可能に統合
- `formatDate`・`getResultText`・`getResultBadgeClass`を共通ユーティリティ（`game-utils.ts`）に抽出
- モーダルのアクセシビリティ改善（Escapeキー対応、aria-labelの適切な設定）
- 結果表記を「引分」から「引き分け」に統一

## テスト

- 単体テストを追加・実行済み

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * モーダルからゲームを選んで登録できるようになりました。
  * 登録済みゲーム一覧の取得と表示を導入しました。

* **改善**
  * ゲーム一覧のレイアウトと日付／結果表示を整備しました。
  * 削除関連のUIとフローを廃止しました。

* **スタイル**
  * 追加ボタンの配置とモーダルの見た目（結果バッジ含む）を強化しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/posiposi/dragons-counter/pull/175?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->