### PR TITLE
GitHub ActionsのMySQLバージョンを8.4.8へ更新

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -17,7 +17,7 @@ jobs:
 
     services:
       mysql:
-        image: mysql:8.0
+        image: mysql:8.4.8
         env:
           MYSQL_ROOT_PASSWORD: ${{ secrets.MYSQL_ROOT_PASSWORD }}
           MYSQL_DATABASE: ${{ secrets.MYSQL_TEST_DATABASE }}


### PR DESCRIPTION
## 概要

GitHub ActionsのMySQLサービスイメージを`mysql:8.0`から`mysql:8.4.8`へ更新し、CIのMySQLバージョンをローカル環境（`docker-compose.yml`）と揃える。

Closes #64

## 変更内容

- `.github/workflows/backend-ci.yml` のMySQLサービスイメージを `8.0` → `8.4.8` へ更新
- Issue本文は `8.4.7` を指定しているが、現在ローカル環境が `8.4.8` に更新済みのため、Issueの「使用バージョンはローカル環境と同様のものである」という要件を優先し `8.4.8` に合わせた

## テスト

- CI設定の変更のため、本PRのGitHub Actions（Backend CI）実行で動作を検証する

🤖 Generated with [Claude Code](https://claude.com/claude-code)