### PR TITLE
観戦試合の削除を中間テーブルの論理削除方式に変更

### DIFF
--- a/backend/src/application/controllers/delete-game.controller.spec.ts
+++ b/backend/src/application/controllers/delete-game.controller.spec.ts
@@ -1,10 +1,13 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { GUARDS_METADATA } from '@nestjs/common/constants';
 import { DeleteGameController } from './delete-game.controller';
 import { DeleteGameUsecase } from '../../domain/usecases/delete-game.usecase';
 import {
   NotFoundException,
   InternalServerErrorException,
 } from '@nestjs/common';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { AdminGuard } from '../admin/guards/admin.guard';
 
 describe('DeleteGameController', () => {
   let controller: DeleteGameController;
@@ -62,5 +65,17 @@ describe('DeleteGameController', () => {
         InternalServerErrorException,
       );
     });
+  });
+
+  it('JwtAuthGuardとAdminGuardがクラスレベルで適用されている', () => {
+    const guards = Reflect.getMetadata(
+      GUARDS_METADATA,
+      DeleteGameController,
+    ) as Array<new (...args: unknown[]) => unknown>;
+
+    expect(guards).toBeDefined();
+    expect(guards).toHaveLength(2);
+    expect(guards[0]).toBe(JwtAuthGuard);
+    expect(guards[1]).toBe(AdminGuard);
   });
 });

--- a/backend/src/application/controllers/delete-game.controller.ts
+++ b/backend/src/application/controllers/delete-game.controller.ts
@@ -4,10 +4,14 @@ import {
   Param,
   HttpCode,
   HttpStatus,
+  UseGuards,
 } from '@nestjs/common';
 import { DeleteGameUsecase } from '../../domain/usecases/delete-game.usecase';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { AdminGuard } from '../admin/guards/admin.guard';
 
 @Controller('games')
+@UseGuards(JwtAuthGuard, AdminGuard)
 export class DeleteGameController {
   constructor(private readonly deleteGameUsecase: DeleteGameUsecase) {}
 

--- a/backend/src/application/controllers/delete-user-game.controller.spec.ts
+++ b/backend/src/application/controllers/delete-user-game.controller.spec.ts
@@ -1,0 +1,79 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { GUARDS_METADATA, HTTP_CODE_METADATA } from '@nestjs/common/constants';
+import { HttpStatus, NotFoundException } from '@nestjs/common';
+import { DeleteUserGameController } from './delete-user-game.controller';
+import { DeleteUserGameUsecase } from '../../domain/usecases/delete-user-game.usecase';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+
+describe('DeleteUserGameController', () => {
+  let controller: DeleteUserGameController;
+  let usecase: DeleteUserGameUsecase;
+
+  const deleteUserGameMethod = Object.getOwnPropertyDescriptor(
+    DeleteUserGameController.prototype,
+    'deleteUserGame',
+  )!.value as (...args: unknown[]) => unknown;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [DeleteUserGameController],
+      providers: [
+        {
+          provide: DeleteUserGameUsecase,
+          useValue: {
+            execute: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    controller = module.get<DeleteUserGameController>(DeleteUserGameController);
+    usecase = module.get<DeleteUserGameUsecase>(DeleteUserGameUsecase);
+  });
+
+  describe('deleteUserGame', () => {
+    const req = { user: { userId: 'user-123', email: 'test@example.com' } };
+    const gameId = 'game-456';
+
+    it('usecaseのexecuteがuserIdとgameIdで呼ばれる', async () => {
+      const executeSpy = jest
+        .spyOn(usecase, 'execute')
+        .mockResolvedValue(undefined);
+
+      await controller.deleteUserGame(req, gameId);
+
+      expect(executeSpy).toHaveBeenCalledTimes(1);
+      expect(executeSpy).toHaveBeenCalledWith('user-123', 'game-456');
+    });
+
+    it('usecaseがrejectした場合に例外が握りつぶされず伝播する', async () => {
+      jest
+        .spyOn(usecase, 'execute')
+        .mockRejectedValue(new NotFoundException('観戦記録が見つかりません'));
+
+      await expect(controller.deleteUserGame(req, gameId)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+
+  it('JwtAuthGuardがクラスレベルで適用されている', () => {
+    const guards = Reflect.getMetadata(
+      GUARDS_METADATA,
+      DeleteUserGameController,
+    ) as Array<new (...args: unknown[]) => unknown>;
+
+    expect(guards).toBeDefined();
+    expect(guards).toHaveLength(1);
+    expect(guards[0]).toBe(JwtAuthGuard);
+  });
+
+  it('HTTPステータスコード204が設定されている', () => {
+    const httpCode = Reflect.getMetadata(
+      HTTP_CODE_METADATA,
+      deleteUserGameMethod,
+    ) as number;
+
+    expect(httpCode).toBe(HttpStatus.NO_CONTENT);
+  });
+});

--- a/backend/src/application/controllers/delete-user-game.controller.ts
+++ b/backend/src/application/controllers/delete-user-game.controller.ts
@@ -1,0 +1,26 @@
+import {
+  Controller,
+  Delete,
+  Param,
+  HttpCode,
+  HttpStatus,
+  UseGuards,
+  Request,
+} from '@nestjs/common';
+import { DeleteUserGameUsecase } from '../../domain/usecases/delete-user-game.usecase';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+
+@Controller('user-games')
+@UseGuards(JwtAuthGuard)
+export class DeleteUserGameController {
+  constructor(private readonly deleteUserGameUsecase: DeleteUserGameUsecase) {}
+
+  @Delete(':gameId')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  async deleteUserGame(
+    @Request() req: { user: { userId: string; email: string } },
+    @Param('gameId') gameId: string,
+  ): Promise<void> {
+    await this.deleteUserGameUsecase.execute(req.user.userId, gameId);
+  }
+}

--- a/backend/src/application/filters/domain-exception.filter.ts
+++ b/backend/src/application/filters/domain-exception.filter.ts
@@ -13,6 +13,7 @@ export class DomainExceptionFilter implements ExceptionFilter {
     NOT_FOUND: HttpStatus.NOT_FOUND,
     USER_NOT_FOUND: HttpStatus.NOT_FOUND,
     GAME_NOT_FOUND: HttpStatus.NOT_FOUND,
+    USER_GAME_NOT_FOUND: HttpStatus.NOT_FOUND,
     ALREADY_EXISTS: HttpStatus.CONFLICT,
     USER_ALREADY_EXISTS: HttpStatus.CONFLICT,
     EMAIL_ALREADY_EXISTS: HttpStatus.CONFLICT,

--- a/backend/src/application/user-game.module.spec.ts
+++ b/backend/src/application/user-game.module.spec.ts
@@ -10,8 +10,10 @@ import { UserGameQueryPort } from '../domain/ports/user-game-query.port';
 import type { GamePort } from '../domain/ports/game.port';
 import { RegisterUserGameUsecase } from '../domain/usecases/register-user-game.usecase';
 import { GetUserGamesUsecase } from '../domain/usecases/get-user-games.usecase';
+import { DeleteUserGameUsecase } from '../domain/usecases/delete-user-game.usecase';
 import { RegisterUserGameController } from './controllers/register-user-game.controller';
 import { GetUserGamesController } from './controllers/get-user-games.controller';
+import { DeleteUserGameController } from './controllers/delete-user-game.controller';
 
 describe('UserGameModule', () => {
   let module: TestingModule;
@@ -64,6 +66,11 @@ describe('UserGameModule', () => {
     expect(usecase).toBeDefined();
   });
 
+  it('DeleteUserGameUsecaseが解決される', () => {
+    const usecase = module.get<DeleteUserGameUsecase>(DeleteUserGameUsecase);
+    expect(usecase).toBeDefined();
+  });
+
   it('RegisterUserGameControllerが解決される', () => {
     const controller = module.get<RegisterUserGameController>(
       RegisterUserGameController,
@@ -74,6 +81,13 @@ describe('UserGameModule', () => {
   it('GetUserGamesControllerが解決される', () => {
     const controller = module.get<GetUserGamesController>(
       GetUserGamesController,
+    );
+    expect(controller).toBeDefined();
+  });
+
+  it('DeleteUserGameControllerが解決される', () => {
+    const controller = module.get<DeleteUserGameController>(
+      DeleteUserGameController,
     );
     expect(controller).toBeDefined();
   });

--- a/backend/src/application/user-game.module.ts
+++ b/backend/src/application/user-game.module.ts
@@ -6,15 +6,22 @@ import { UserGameQueryAdapter } from '../infrastructure/adapters/user-game-query
 import { GameModule } from './game.module';
 import { RegisterUserGameUsecase } from '../domain/usecases/register-user-game.usecase';
 import { GetUserGamesUsecase } from '../domain/usecases/get-user-games.usecase';
+import { DeleteUserGameUsecase } from '../domain/usecases/delete-user-game.usecase';
 import { RegisterUserGameController } from './controllers/register-user-game.controller';
 import { GetUserGamesController } from './controllers/get-user-games.controller';
+import { DeleteUserGameController } from './controllers/delete-user-game.controller';
 
 @Module({
   imports: [TypeOrmModule.forFeature([UserGameEntity]), GameModule],
-  controllers: [RegisterUserGameController, GetUserGamesController],
+  controllers: [
+    RegisterUserGameController,
+    GetUserGamesController,
+    DeleteUserGameController,
+  ],
   providers: [
     RegisterUserGameUsecase,
     GetUserGamesUsecase,
+    DeleteUserGameUsecase,
     {
       provide: 'UserGameCommandPort',
       useClass: UserGameCommandAdapter,

--- a/backend/src/domain/exceptions/user-game-not-found.exception.spec.ts
+++ b/backend/src/domain/exceptions/user-game-not-found.exception.spec.ts
@@ -1,0 +1,23 @@
+import { DomainException } from './domain-exception';
+import { UserGameNotFoundException } from './user-game-not-found.exception';
+
+describe('UserGameNotFoundException', () => {
+  it('DomainExceptionを継承していること', () => {
+    const exception = new UserGameNotFoundException('観戦記録が見つかりません');
+
+    expect(exception).toBeInstanceOf(DomainException);
+  });
+
+  it('エラーコードがUSER_GAME_NOT_FOUNDであること', () => {
+    const exception = new UserGameNotFoundException('観戦記録が見つかりません');
+
+    expect(exception.code).toBe('USER_GAME_NOT_FOUND');
+  });
+
+  it('メッセージが正しく設定されること', () => {
+    const message = '観戦記録が見つかりません';
+    const exception = new UserGameNotFoundException(message);
+
+    expect(exception.message).toBe(message);
+  });
+});

--- a/backend/src/domain/exceptions/user-game-not-found.exception.ts
+++ b/backend/src/domain/exceptions/user-game-not-found.exception.ts
@@ -1,0 +1,7 @@
+import { DomainException } from './domain-exception';
+
+export class UserGameNotFoundException extends DomainException {
+  constructor(message: string) {
+    super('USER_GAME_NOT_FOUND', message);
+  }
+}

--- a/backend/src/domain/usecases/delete-user-game.usecase.spec.ts
+++ b/backend/src/domain/usecases/delete-user-game.usecase.spec.ts
@@ -1,0 +1,101 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { NotFoundException } from '@nestjs/common';
+import { DeleteUserGameUsecase } from './delete-user-game.usecase';
+import { UserGame } from '../entities/user-game';
+import { UserId } from '../value-objects/user-id';
+import { GameId } from '../value-objects/game-id';
+
+describe('DeleteUserGameUsecase', () => {
+  let usecase: DeleteUserGameUsecase;
+  let mockUserGameCommandPort: {
+    softDelete: jest.Mock<Promise<void>, [UserId, GameId]>;
+  };
+  let mockUserGameQueryPort: {
+    findByUserIdAndGameId: jest.Mock;
+  };
+
+  beforeEach(async () => {
+    mockUserGameCommandPort = {
+      softDelete: jest.fn<Promise<void>, [UserId, GameId]>(),
+    };
+    mockUserGameQueryPort = {
+      findByUserIdAndGameId: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        DeleteUserGameUsecase,
+        {
+          provide: 'UserGameCommandPort',
+          useValue: mockUserGameCommandPort,
+        },
+        {
+          provide: 'UserGameQueryPort',
+          useValue: mockUserGameQueryPort,
+        },
+      ],
+    }).compile();
+
+    usecase = module.get<DeleteUserGameUsecase>(DeleteUserGameUsecase);
+  });
+
+  describe('execute', () => {
+    const userId = 'user-123';
+    const gameId = 'game-456';
+
+    describe('正常系', () => {
+      it('対象レコードが存在する場合softDeleteが呼ばれる', async () => {
+        mockUserGameQueryPort.findByUserIdAndGameId.mockResolvedValue(
+          {} as UserGame,
+        );
+        mockUserGameCommandPort.softDelete.mockResolvedValue(undefined);
+
+        await usecase.execute(userId, gameId);
+
+        expect(
+          mockUserGameQueryPort.findByUserIdAndGameId,
+        ).toHaveBeenCalledWith(expect.any(UserId), expect.any(GameId));
+        expect(mockUserGameCommandPort.softDelete).toHaveBeenCalledWith(
+          expect.any(UserId),
+          expect.any(GameId),
+        );
+      });
+
+      it('softDeleteに渡されるuserId・gameIdが正しい', async () => {
+        mockUserGameQueryPort.findByUserIdAndGameId.mockResolvedValue(
+          {} as UserGame,
+        );
+        mockUserGameCommandPort.softDelete.mockResolvedValue(undefined);
+
+        await usecase.execute(userId, gameId);
+
+        const [passedUserId, passedGameId] =
+          mockUserGameCommandPort.softDelete.mock.calls[0];
+        expect(passedUserId.value).toBe(userId);
+        expect(passedGameId.value).toBe(gameId);
+      });
+    });
+
+    describe('異常系', () => {
+      it('対象レコードが存在しない場合NotFoundExceptionがスローされる', async () => {
+        mockUserGameQueryPort.findByUserIdAndGameId.mockResolvedValue(null);
+
+        await expect(usecase.execute(userId, gameId)).rejects.toThrow(
+          NotFoundException,
+        );
+
+        expect(mockUserGameCommandPort.softDelete).not.toHaveBeenCalled();
+      });
+
+      it('他ユーザーの観戦記録は削除できずNotFoundExceptionがスローされる', async () => {
+        mockUserGameQueryPort.findByUserIdAndGameId.mockResolvedValue(null);
+
+        await expect(usecase.execute(userId, gameId)).rejects.toThrow(
+          NotFoundException,
+        );
+
+        expect(mockUserGameCommandPort.softDelete).not.toHaveBeenCalled();
+      });
+    });
+  });
+});

--- a/backend/src/domain/usecases/delete-user-game.usecase.spec.ts
+++ b/backend/src/domain/usecases/delete-user-game.usecase.spec.ts
@@ -1,6 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { NotFoundException } from '@nestjs/common';
 import { DeleteUserGameUsecase } from './delete-user-game.usecase';
+import { UserGameNotFoundException } from '../exceptions/user-game-not-found.exception';
 import { UserGame } from '../entities/user-game';
 import { UserId } from '../value-objects/user-id';
 import { GameId } from '../value-objects/game-id';
@@ -11,7 +11,10 @@ describe('DeleteUserGameUsecase', () => {
     softDelete: jest.Mock<Promise<void>, [UserId, GameId]>;
   };
   let mockUserGameQueryPort: {
-    findByUserIdAndGameId: jest.Mock;
+    findByUserIdAndGameId: jest.Mock<
+      Promise<UserGame | null>,
+      [UserId, GameId]
+    >;
   };
 
   beforeEach(async () => {
@@ -19,7 +22,10 @@ describe('DeleteUserGameUsecase', () => {
       softDelete: jest.fn<Promise<void>, [UserId, GameId]>(),
     };
     mockUserGameQueryPort = {
-      findByUserIdAndGameId: jest.fn(),
+      findByUserIdAndGameId: jest.fn<
+        Promise<UserGame | null>,
+        [UserId, GameId]
+      >(),
     };
 
     const module: TestingModule = await Test.createTestingModule({
@@ -77,23 +83,28 @@ describe('DeleteUserGameUsecase', () => {
     });
 
     describe('異常系', () => {
-      it('対象レコードが存在しない場合NotFoundExceptionがスローされる', async () => {
+      it('対象レコードが存在しない場合UserGameNotFoundExceptionがスローされる', async () => {
         mockUserGameQueryPort.findByUserIdAndGameId.mockResolvedValue(null);
 
         await expect(usecase.execute(userId, gameId)).rejects.toThrow(
-          NotFoundException,
+          UserGameNotFoundException,
         );
 
         expect(mockUserGameCommandPort.softDelete).not.toHaveBeenCalled();
       });
 
-      it('他ユーザーの観戦記録は削除できずNotFoundExceptionがスローされる', async () => {
+      it('他ユーザーのIDで検索され該当なしの場合UserGameNotFoundExceptionがスローされる', async () => {
+        const otherUserId = 'other-user-999';
         mockUserGameQueryPort.findByUserIdAndGameId.mockResolvedValue(null);
 
-        await expect(usecase.execute(userId, gameId)).rejects.toThrow(
-          NotFoundException,
+        await expect(usecase.execute(otherUserId, gameId)).rejects.toThrow(
+          UserGameNotFoundException,
         );
 
+        const [passedUserId, passedGameId] =
+          mockUserGameQueryPort.findByUserIdAndGameId.mock.calls[0];
+        expect(passedUserId.value).toBe(otherUserId);
+        expect(passedGameId.value).toBe(gameId);
         expect(mockUserGameCommandPort.softDelete).not.toHaveBeenCalled();
       });
     });

--- a/backend/src/domain/usecases/delete-user-game.usecase.ts
+++ b/backend/src/domain/usecases/delete-user-game.usecase.ts
@@ -1,0 +1,30 @@
+import { Injectable, Inject, NotFoundException } from '@nestjs/common';
+import type { UserGameCommandPort } from '../ports/user-game-command.port';
+import type { UserGameQueryPort } from '../ports/user-game-query.port';
+import { UserId } from '../value-objects/user-id';
+import { GameId } from '../value-objects/game-id';
+
+@Injectable()
+export class DeleteUserGameUsecase {
+  constructor(
+    @Inject('UserGameCommandPort')
+    private readonly userGameCommandPort: UserGameCommandPort,
+    @Inject('UserGameQueryPort')
+    private readonly userGameQueryPort: UserGameQueryPort,
+  ) {}
+
+  async execute(userId: string, gameId: string): Promise<void> {
+    const userIdVO = UserId.create(userId);
+    const gameIdVO = new GameId(gameId);
+
+    const userGame = await this.userGameQueryPort.findByUserIdAndGameId(
+      userIdVO,
+      gameIdVO,
+    );
+    if (!userGame) {
+      throw new NotFoundException('観戦記録が見つかりません');
+    }
+
+    await this.userGameCommandPort.softDelete(userIdVO, gameIdVO);
+  }
+}

--- a/backend/src/domain/usecases/delete-user-game.usecase.ts
+++ b/backend/src/domain/usecases/delete-user-game.usecase.ts
@@ -1,8 +1,9 @@
-import { Injectable, Inject, NotFoundException } from '@nestjs/common';
+import { Injectable, Inject } from '@nestjs/common';
 import type { UserGameCommandPort } from '../ports/user-game-command.port';
 import type { UserGameQueryPort } from '../ports/user-game-query.port';
 import { UserId } from '../value-objects/user-id';
 import { GameId } from '../value-objects/game-id';
+import { UserGameNotFoundException } from '../exceptions/user-game-not-found.exception';
 
 @Injectable()
 export class DeleteUserGameUsecase {
@@ -22,7 +23,7 @@ export class DeleteUserGameUsecase {
       gameIdVO,
     );
     if (!userGame) {
-      throw new NotFoundException('観戦記録が見つかりません');
+      throw new UserGameNotFoundException('観戦記録が見つかりません');
     }
 
     await this.userGameCommandPort.softDelete(userIdVO, gameIdVO);

--- a/frontend/src/components/DeleteConfirmDialog.module.css
+++ b/frontend/src/components/DeleteConfirmDialog.module.css
@@ -56,10 +56,25 @@
   margin-bottom: 24px;
 }
 
+.error {
+  background: #fee;
+  color: #dc2626;
+  border-radius: 8px;
+  padding: 12px;
+  margin-bottom: 16px;
+  font-size: 0.875rem;
+}
+
 .actions {
   display: flex;
   gap: 12px;
   justify-content: flex-end;
+}
+
+.cancelButton:disabled,
+.confirmButton:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
 }
 
 .cancelButton,

--- a/frontend/src/components/DeleteConfirmDialog.tsx
+++ b/frontend/src/components/DeleteConfirmDialog.tsx
@@ -6,6 +6,8 @@ interface DeleteConfirmDialogProps {
   onCancel: () => void;
   opponent: string;
   gameDate: string;
+  errorMessage?: string | null;
+  isProcessing?: boolean;
 }
 
 export default function DeleteConfirmDialog({
@@ -14,6 +16,8 @@ export default function DeleteConfirmDialog({
   onCancel,
   opponent,
   gameDate,
+  errorMessage = null,
+  isProcessing = false,
 }: DeleteConfirmDialogProps) {
   if (!isOpen) return null;
 
@@ -28,19 +32,33 @@ export default function DeleteConfirmDialog({
 
   return (
     <div className={styles.overlay} onClick={onCancel}>
-      <div className={styles.dialog} onClick={(e) => e.stopPropagation()}>
-        <h3 className={styles.title}>試合記録を削除しますか？</h3>
+      <div
+        className={styles.dialog}
+        role="dialog"
+        aria-modal="true"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h3 className={styles.title}>観戦記録を削除しますか？</h3>
         <p className={styles.message}>
-          {formatDate(gameDate)} の {opponent} 戦の記録を削除します。
+          {formatDate(gameDate)} の {opponent} 戦の観戦記録を削除します。
           <br />
           この操作は取り消せません。
         </p>
+        {errorMessage && <div className={styles.error}>{errorMessage}</div>}
         <div className={styles.actions}>
-          <button className={styles.cancelButton} onClick={onCancel}>
+          <button
+            className={styles.cancelButton}
+            onClick={onCancel}
+            disabled={isProcessing}
+          >
             キャンセル
           </button>
-          <button className={styles.confirmButton} onClick={onConfirm}>
-            OK
+          <button
+            className={styles.confirmButton}
+            onClick={onConfirm}
+            disabled={isProcessing}
+          >
+            {isProcessing ? "削除中..." : "OK"}
           </button>
         </div>
       </div>

--- a/frontend/src/components/GameList.tsx
+++ b/frontend/src/components/GameList.tsx
@@ -1,15 +1,20 @@
 import { useState, useEffect } from "react";
 import { useNavigate, Link } from "react-router-dom";
 import { UserGame } from "@/types/user-game";
-import { fetchUserGames, registerUserGame } from "@/lib/api/user-games";
+import {
+  fetchUserGames,
+  registerUserGame,
+  deleteUserGame,
+} from "@/lib/api/user-games";
 import {
   formatGameDate,
   getResultText,
   getResultBadgeClass,
 } from "@/lib/game-utils";
 import { useAuth } from "@/hooks/use-auth";
-import { LogOut, Settings, Plus } from "lucide-react";
+import { LogOut, Settings, Plus, Trash2 } from "lucide-react";
 import GameSelectModal from "./GameSelectModal";
+import DeleteConfirmDialog from "./DeleteConfirmDialog";
 import styles from "./GameList.module.css";
 
 export default function GameList() {
@@ -19,6 +24,9 @@ export default function GameList() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const [deleteTarget, setDeleteTarget] = useState<UserGame | null>(null);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
+  const [isDeleting, setIsDeleting] = useState(false);
 
   useEffect(() => {
     loadUserGames();
@@ -41,6 +49,27 @@ export default function GameList() {
   const handleRegister = async (gameId: string) => {
     await registerUserGame(gameId);
     await loadUserGames();
+  };
+
+  const handleDeleteConfirm = async () => {
+    if (!deleteTarget || isDeleting) return;
+    try {
+      setIsDeleting(true);
+      setDeleteError(null);
+      await deleteUserGame(deleteTarget.gameId);
+      setDeleteTarget(null);
+      await loadUserGames();
+    } catch (err) {
+      setDeleteError("観戦記録の削除に失敗しました");
+      console.error("Failed to delete user game:", err);
+    } finally {
+      setIsDeleting(false);
+    }
+  };
+
+  const handleDeleteCancel = () => {
+    setDeleteTarget(null);
+    setDeleteError(null);
   };
 
   const calculateStats = () => {
@@ -143,11 +172,21 @@ export default function GameList() {
                   <span className={styles.gameDate}>
                     {formatGameDate(game.gameDate)}
                   </span>
-                  <span
-                    className={`${styles.resultBadge} ${getResultBadgeClass(game.result, styles)}`}
-                  >
-                    {getResultText(game.result)}
-                  </span>
+                  <div className={styles.gameHeaderActions}>
+                    <span
+                      className={`${styles.resultBadge} ${getResultBadgeClass(game.result, styles)}`}
+                    >
+                      {getResultText(game.result)}
+                    </span>
+                    <button
+                      type="button"
+                      className={styles.deleteButton}
+                      aria-label="削除"
+                      onClick={() => setDeleteTarget(game)}
+                    >
+                      <Trash2 size={18} />
+                    </button>
+                  </div>
                 </div>
                 <div className={styles.gameContent}>
                   <div className={styles.opponent}>vs {game.opponent}</div>
@@ -180,6 +219,16 @@ export default function GameList() {
         onClose={() => setIsModalOpen(false)}
         onRegister={handleRegister}
         registeredGameIds={games.map((game) => game.gameId)}
+      />
+
+      <DeleteConfirmDialog
+        isOpen={deleteTarget !== null}
+        onConfirm={handleDeleteConfirm}
+        onCancel={handleDeleteCancel}
+        opponent={deleteTarget?.opponent ?? ""}
+        gameDate={deleteTarget?.gameDate ?? ""}
+        errorMessage={deleteError}
+        isProcessing={isDeleting}
       />
     </div>
   );

--- a/frontend/src/components/GameList.tsx
+++ b/frontend/src/components/GameList.tsx
@@ -57,14 +57,15 @@ export default function GameList() {
       setIsDeleting(true);
       setDeleteError(null);
       await deleteUserGame(deleteTarget.gameId);
-      setDeleteTarget(null);
-      await loadUserGames();
     } catch (err) {
       setDeleteError("観戦記録の削除に失敗しました");
       console.error("Failed to delete user game:", err);
+      return;
     } finally {
       setIsDeleting(false);
     }
+    setDeleteTarget(null);
+    await loadUserGames();
   };
 
   const handleDeleteCancel = () => {

--- a/frontend/src/components/__tests__/DeleteConfirmDialog.test.tsx
+++ b/frontend/src/components/__tests__/DeleteConfirmDialog.test.tsx
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import DeleteConfirmDialog from "../DeleteConfirmDialog";
+
+describe("DeleteConfirmDialog", () => {
+  const baseProps = {
+    onConfirm: vi.fn(),
+    onCancel: vi.fn(),
+    opponent: "巨人",
+    gameDate: "2024-04-01",
+  };
+
+  it("isOpenがfalseのとき何も表示しない", () => {
+    const { container } = render(
+      <DeleteConfirmDialog {...baseProps} isOpen={false} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("isOpenがtrueのとき観戦記録向けのタイトルを表示する", () => {
+    render(<DeleteConfirmDialog {...baseProps} isOpen={true} />);
+    expect(screen.getByText("観戦記録を削除しますか？")).toBeInTheDocument();
+  });
+
+  it("対象の観戦記録（対戦相手）が分かる本文を表示する", () => {
+    render(<DeleteConfirmDialog {...baseProps} isOpen={true} />);
+    const body = screen.getByText(/巨人/);
+    expect(body).toBeInTheDocument();
+    expect(body).toHaveTextContent("観戦記録");
+  });
+
+  it("OKボタン押下でonConfirmが呼ばれる", async () => {
+    const onConfirm = vi.fn();
+    render(
+      <DeleteConfirmDialog
+        {...baseProps}
+        isOpen={true}
+        onConfirm={onConfirm}
+      />,
+    );
+    await userEvent.click(screen.getByRole("button", { name: "OK" }));
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it("キャンセルボタン押下でonCancelが呼ばれる", async () => {
+    const onCancel = vi.fn();
+    render(
+      <DeleteConfirmDialog {...baseProps} isOpen={true} onCancel={onCancel} />,
+    );
+    await userEvent.click(screen.getByRole("button", { name: "キャンセル" }));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("errorMessageが渡されたときダイアログ内にエラーを表示する", () => {
+    render(
+      <DeleteConfirmDialog
+        {...baseProps}
+        isOpen={true}
+        errorMessage="観戦記録の削除に失敗しました"
+      />,
+    );
+    expect(
+      screen.getByText("観戦記録の削除に失敗しました"),
+    ).toBeInTheDocument();
+  });
+
+  it("isProcessingがtrueのとき確定ボタンを無効化する", () => {
+    render(
+      <DeleteConfirmDialog {...baseProps} isOpen={true} isProcessing={true} />,
+    );
+    expect(screen.getByRole("button", { name: "削除中..." })).toBeDisabled();
+  });
+});

--- a/frontend/src/components/__tests__/GameList.test.tsx
+++ b/frontend/src/components/__tests__/GameList.test.tsx
@@ -1,0 +1,178 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import GameList from "../GameList";
+import { UserGame } from "@/types/user-game";
+
+vi.mock("@/lib/api/user-games", () => ({
+  fetchUserGames: vi.fn(),
+  registerUserGame: vi.fn(),
+  deleteUserGame: vi.fn(),
+}));
+
+vi.mock("@/hooks/use-auth", () => ({
+  useAuth: vi.fn(),
+}));
+
+import { fetchUserGames, deleteUserGame } from "@/lib/api/user-games";
+import { useAuth } from "@/hooks/use-auth";
+
+const fetchUserGamesMock = vi.mocked(fetchUserGames);
+const deleteUserGameMock = vi.mocked(deleteUserGame);
+const useAuthMock = vi.mocked(useAuth);
+
+// id（中間レコードid）と gameId は別値を維持し、削除APIに渡す値の取り違えを検出する
+const firstGame: UserGame = {
+  id: "user-game-1",
+  gameId: "game-abc",
+  gameDate: "2024-04-01",
+  opponent: "巨人",
+  dragonsScore: 5,
+  opponentScore: 3,
+  result: "win",
+  stadium: "バンテリンドーム",
+  impression: null,
+  createdAt: "2024-04-01T00:00:00.000Z",
+};
+
+const secondGame: UserGame = {
+  id: "user-game-2",
+  gameId: "game-xyz",
+  gameDate: "2024-04-05",
+  opponent: "阪神",
+  dragonsScore: 1,
+  opponentScore: 4,
+  result: "lose",
+  stadium: "甲子園",
+  impression: null,
+  createdAt: "2024-04-05T00:00:00.000Z",
+};
+
+function renderGameList() {
+  return render(
+    <MemoryRouter>
+      <GameList />
+    </MemoryRouter>,
+  );
+}
+
+describe("GameList 削除UI", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useAuthMock.mockReturnValue({
+      user: { role: "USER" },
+      signout: vi.fn().mockResolvedValue(undefined),
+    } as unknown as ReturnType<typeof useAuth>);
+  });
+
+  it("削除ボタン押下で確認ダイアログが表示される", async () => {
+    fetchUserGamesMock.mockResolvedValue([firstGame]);
+    renderGameList();
+
+    await waitFor(() =>
+      expect(screen.getByText("vs 巨人")).toBeInTheDocument(),
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "削除" }));
+
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByText("観戦記録を削除しますか？")).toBeInTheDocument();
+  });
+
+  it("ダイアログ確認でdeleteUserGameがgameIdで呼ばれ、再読込される", async () => {
+    fetchUserGamesMock.mockResolvedValue([firstGame]);
+    deleteUserGameMock.mockResolvedValue(undefined);
+    renderGameList();
+
+    await waitFor(() =>
+      expect(screen.getByText("vs 巨人")).toBeInTheDocument(),
+    );
+    expect(fetchUserGamesMock).toHaveBeenCalledTimes(1);
+
+    await userEvent.click(screen.getByRole("button", { name: "削除" }));
+
+    const dialog = screen.getByRole("dialog");
+    await userEvent.click(within(dialog).getByRole("button", { name: "OK" }));
+
+    await waitFor(() =>
+      expect(deleteUserGameMock).toHaveBeenCalledWith("game-abc"),
+    );
+    await waitFor(() => expect(fetchUserGamesMock).toHaveBeenCalledTimes(2));
+  });
+
+  it("2番目の試合の削除ボタン押下でその試合のgameIdが削除APIに渡る", async () => {
+    fetchUserGamesMock.mockResolvedValue([firstGame, secondGame]);
+    deleteUserGameMock.mockResolvedValue(undefined);
+    renderGameList();
+
+    await waitFor(() =>
+      expect(screen.getByText("vs 阪神")).toBeInTheDocument(),
+    );
+
+    const deleteButtons = screen.getAllByRole("button", { name: "削除" });
+    await userEvent.click(deleteButtons[1]);
+
+    const dialog = screen.getByRole("dialog");
+    expect(within(dialog).getByText(/阪神/)).toBeInTheDocument();
+    await userEvent.click(within(dialog).getByRole("button", { name: "OK" }));
+
+    await waitFor(() =>
+      expect(deleteUserGameMock).toHaveBeenCalledWith("game-xyz"),
+    );
+  });
+
+  it("キャンセル押下でdeleteUserGameは呼ばれずダイアログが閉じる", async () => {
+    fetchUserGamesMock.mockResolvedValue([firstGame]);
+    renderGameList();
+
+    await waitFor(() =>
+      expect(screen.getByText("vs 巨人")).toBeInTheDocument(),
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "削除" }));
+    const dialog = screen.getByRole("dialog");
+    await userEvent.click(
+      within(dialog).getByRole("button", { name: "キャンセル" }),
+    );
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    expect(deleteUserGameMock).not.toHaveBeenCalled();
+  });
+
+  it("削除失敗時はダイアログ内にエラーを表示しリストを残して再試行できる", async () => {
+    fetchUserGamesMock.mockResolvedValue([firstGame]);
+    deleteUserGameMock
+      .mockRejectedValueOnce(new Error("削除に失敗"))
+      .mockResolvedValueOnce(undefined);
+    renderGameList();
+
+    await waitFor(() =>
+      expect(screen.getByText("vs 巨人")).toBeInTheDocument(),
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "削除" }));
+    await userEvent.click(
+      within(screen.getByRole("dialog")).getByRole("button", { name: "OK" }),
+    );
+
+    await waitFor(() =>
+      expect(
+        within(screen.getByRole("dialog")).getByText(
+          "観戦記録の削除に失敗しました",
+        ),
+      ).toBeInTheDocument(),
+    );
+    expect(screen.getByText("vs 巨人")).toBeInTheDocument();
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+
+    await userEvent.click(
+      within(screen.getByRole("dialog")).getByRole("button", { name: "OK" }),
+    );
+
+    await waitFor(() => expect(deleteUserGameMock).toHaveBeenCalledTimes(2));
+    await waitFor(() =>
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument(),
+    );
+  });
+});

--- a/frontend/src/components/__tests__/GameList.test.tsx
+++ b/frontend/src/components/__tests__/GameList.test.tsx
@@ -140,6 +140,30 @@ describe("GameList 削除UI", () => {
     expect(deleteUserGameMock).not.toHaveBeenCalled();
   });
 
+  it("削除成功後の再読込が失敗しても削除失敗エラーは表示されない", async () => {
+    fetchUserGamesMock
+      .mockResolvedValueOnce([firstGame])
+      .mockRejectedValueOnce(new Error("再読込に失敗"));
+    deleteUserGameMock.mockResolvedValue(undefined);
+    renderGameList();
+
+    await waitFor(() =>
+      expect(screen.getByText("vs 巨人")).toBeInTheDocument(),
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "削除" }));
+    await userEvent.click(
+      within(screen.getByRole("dialog")).getByRole("button", { name: "OK" }),
+    );
+
+    await waitFor(() => expect(deleteUserGameMock).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(fetchUserGamesMock).toHaveBeenCalledTimes(2));
+
+    expect(
+      screen.queryByText("観戦記録の削除に失敗しました"),
+    ).not.toBeInTheDocument();
+  });
+
   it("削除失敗時はダイアログ内にエラーを表示しリストを残して再試行できる", async () => {
     fetchUserGamesMock.mockResolvedValue([firstGame]);
     deleteUserGameMock

--- a/frontend/src/lib/api/__tests__/user-games.test.ts
+++ b/frontend/src/lib/api/__tests__/user-games.test.ts
@@ -1,0 +1,105 @@
+import { getCsrfToken } from "@/lib/csrf";
+
+vi.mock("@/lib/csrf", () => ({
+  getCsrfToken: vi.fn(),
+}));
+
+const getCsrfTokenMock = vi.mocked(getCsrfToken);
+
+async function importDeleteUserGame() {
+  const module = await import("@/lib/api/user-games");
+  return module.deleteUserGame;
+}
+
+describe("deleteUserGame", () => {
+  const gameId = "game-123";
+
+  beforeEach(() => {
+    vi.resetModules();
+    vi.stubEnv("VITE_API_URL", "http://localhost:3000");
+    getCsrfTokenMock.mockReturnValue("csrf-token-value");
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  it("正しいURL・メソッド・認証情報・CSRFヘッダでfetchを呼び出す", async () => {
+    const fetchSpy = vi
+      .spyOn(global, "fetch")
+      .mockResolvedValue(new Response(null, { status: 204 }));
+    const deleteUserGame = await importDeleteUserGame();
+
+    await deleteUserGame(gameId);
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "http://localhost:3000/user-games/game-123",
+      {
+        method: "DELETE",
+        headers: {
+          "Content-Type": "application/json",
+          "X-CSRF-Token": "csrf-token-value",
+        },
+        credentials: "include",
+      },
+    );
+  });
+
+  it("CSRFトークンが取得できない場合はX-CSRF-Tokenヘッダを付与しない", async () => {
+    getCsrfTokenMock.mockReturnValue(null);
+    const fetchSpy = vi
+      .spyOn(global, "fetch")
+      .mockResolvedValue(new Response(null, { status: 204 }));
+    const deleteUserGame = await importDeleteUserGame();
+
+    await deleteUserGame(gameId);
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "http://localhost:3000/user-games/game-123",
+      {
+        method: "DELETE",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        credentials: "include",
+      },
+    );
+  });
+
+  it("レスポンスが失敗のときはbodyのmessageをメッセージにErrorをthrowする", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ message: "削除できませんでした" }), {
+        status: 400,
+      }),
+    );
+    const deleteUserGame = await importDeleteUserGame();
+
+    await expect(deleteUserGame(gameId)).rejects.toThrow(
+      "削除できませんでした",
+    );
+  });
+
+  it("レスポンスが失敗でbodyが無いときは既定のメッセージでErrorをthrowする", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValue(
+      new Response(null, { status: 500 }),
+    );
+    const deleteUserGame = await importDeleteUserGame();
+
+    await expect(deleteUserGame(gameId)).rejects.toThrow(
+      "観戦記録の削除に失敗しました",
+    );
+  });
+
+  it("API_BASE_URLが未設定のときはErrorをthrowする", async () => {
+    vi.resetModules();
+    vi.stubEnv("VITE_API_URL", "");
+    const fetchSpy = vi.spyOn(global, "fetch");
+    const deleteUserGame = await importDeleteUserGame();
+
+    await expect(deleteUserGame(gameId)).rejects.toThrow(
+      "予期しないエラーが発生しました。しばらく経ってから再度お試しください",
+    );
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/lib/api/user-games.ts
+++ b/frontend/src/lib/api/user-games.ts
@@ -48,3 +48,26 @@ export async function registerUserGame(gameId: string): Promise<void> {
     throw new Error("観戦記録の登録に失敗しました");
   }
 }
+
+export async function deleteUserGame(gameId: string): Promise<void> {
+  if (!API_BASE_URL) {
+    throw new Error(
+      "予期しないエラーが発生しました。しばらく経ってから再度お試しください",
+    );
+  }
+
+  const csrfToken = getCsrfToken();
+  const response = await fetch(`${API_BASE_URL}/user-games/${gameId}`, {
+    method: "DELETE",
+    headers: {
+      "Content-Type": "application/json",
+      ...(csrfToken ? { "X-CSRF-Token": csrfToken } : {}),
+    },
+    credentials: "include",
+  });
+
+  if (!response.ok) {
+    const body = await response.json().catch(() => null);
+    throw new Error(body?.message ?? "観戦記録の削除に失敗しました");
+  }
+}


### PR DESCRIPTION
## 概要

ユーザーの「観戦試合の削除」を、試合マスタ（games）の物理削除ではなく中間テーブル（users_games）の論理削除に変更します。これにより、ユーザーは自分の観戦記録のみを削除でき、試合マスタや他ユーザーの記録に影響を与えません。

Closes #130

## 変更内容

### backend

- 認証ユーザー自身の観戦記録のみを論理削除する `DeleteUserGameUsecase` を追加（存在・所有確認の上、未所有時は NotFound）
- `DELETE /api/user-games/:gameId` エンドポイントを追加（`JwtAuthGuard`・204 No Content）し、`UserGameModule` に登録
- 既存の `DELETE /api/games/:gameId`（試合マスタ削除）を `JwtAuthGuard` + `AdminGuard` で管理者専用化
- 論理削除のインフラ層（`@DeleteDateColumn`・`CommandAdapter.softDelete`・`deleted_at` 列）は既存実装を活用し、追加マイグレーションは不要

### frontend

- 観戦記録を削除する `deleteUserGame` API 関数を追加
- `GameList` に削除ボタンと観戦記録向け文言の `DeleteConfirmDialog` を追加
- 削除失敗時はダイアログ内にエラーを表示して再試行可能とし、多重実行を防止

## テスト

- backend（unit + integration）・frontend ともに単体テストを追加・実行済み（全GREEN）

## 補足

- Issue本文はPrisma記法で記載されていますが、本リポジトリの実態はTypeORMのため読み替えて実装しています（スコープ逸脱なし）
- `UserGame` エンティティへの `deletedAt`/`isDeleted()` 追加は、論理削除がTypeORM側で完結するためYAGNI判断で見送りました

🤖 Generated with [Claude Code](https://claude.com/claude-code)