### PR TITLE
PR-02 Go用CI（backend-go-ci.yml）を追加

### DIFF
--- a/.github/workflows/backend-go-ci.yml
+++ b/.github/workflows/backend-go-ci.yml
@@ -1,0 +1,62 @@
+name: Backend Go CI
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  lint-and-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: ./backend-go
+
+    services:
+      mysql:
+        image: mysql:8.4.8
+        env:
+          MYSQL_ROOT_PASSWORD: ${{ secrets.MYSQL_ROOT_PASSWORD }}
+          MYSQL_DATABASE: ${{ secrets.MYSQL_TEST_DATABASE }}
+          MYSQL_USER: ${{ secrets.MYSQL_TEST_USER }}
+          MYSQL_PASSWORD: ${{ secrets.MYSQL_TEST_PASSWORD }}
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd "mysqladmin ping -h 127.0.0.1"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: backend-go/go.mod
+          cache-dependency-path: backend-go/go.sum
+
+      - name: Check formatting
+        run: |
+          diff=$(gofmt -l .)
+          if [ -n "$diff" ]; then
+            echo "gofmt でフォーマットが必要なファイルがあります:"
+            echo "$diff"
+            exit 1
+          fi
+
+      - name: Build
+        run: go build ./...
+
+      - name: Run go vet
+        run: go vet ./...
+
+      - name: Run tests
+        run: go test ./...

--- a/backend-go/internal/config/config.go
+++ b/backend-go/internal/config/config.go
@@ -6,11 +6,11 @@ import (
 )
 
 type Config struct {
-	Env string
-	Addr string
+	Env        string
+	Addr       string
 	TLSEnabled bool
-	CertFile string
-	KeyFile string
+	CertFile   string
+	KeyFile    string
 }
 
 func Load() Config {


### PR DESCRIPTION
## 概要

Issue #195 (親: #188 Phase 0) の対応。`backend-go/` の Go コードを検証する GitHub Actions CI（`backend-go-ci.yml`）を新設する。

## 変更内容

- `.github/workflows/backend-go-ci.yml` を新規追加
  - `pull_request` / `push`(main) / `workflow_dispatch` で起動
  - `lint-and-test` ジョブで `gofmt`チェック → `go build` → `go vet` → `go test` を実行
  - `mysql:8.4.8` service コンテナの枠を用意（unit段階では未使用、既存 `backend-ci.yml` と同じ secrets を使用）
  - `actions/setup-go@v6` + `go-version-file: backend-go/go.mod`
- `backend-go/internal/config/config.go` を `gofmt` で整形（gofmtチェックを緑にするため。structフィールドのアライメントのみ）

## 方針（Issueからの変更点）

- Issue原文スコープの `golangci-lint` は **CIに含めない**方針に変更（[Issueコメント](https://github.com/posiposi/dragons-counter/issues/195#issuecomment-4885278205)参照）。golangci-lint は必要時にローカルコンテナで都度実行する運用とし、`.golangci.yml` も作成しない。
- CI構成は `posiposi/mare-scientiae` の `.github/workflows/lint-and-test.yml` を参考に、`backend-go/` 構成・mysql前提に適合。

## テスト観点

- CI が PR-01 のテスト（`internal/config`, `internal/router`）を実行し緑になること
- ローカルで `go build ./...` / `go vet ./...` / `go test ./...` / `gofmt -l .`（空出力）を確認済み

Closes #195

🤖 Generated with [Claude Code](https://claude.com/claude-code)