### PR TITLE
Go基盤の設定ロード・DSN変換・構造化ログを実装

### DIFF
--- a/backend-go/cmd/api/main.go
+++ b/backend-go/cmd/api/main.go
@@ -1,19 +1,23 @@
 package main
 
 import (
-	"log"
 	"net/http"
+	"os"
 	"time"
 
 	"github.com/posiposi/dragons-counter/backend-go/internal/config"
+	"github.com/posiposi/dragons-counter/backend-go/internal/logger"
 	"github.com/posiposi/dragons-counter/backend-go/internal/router"
 )
 
 func main() {
 	cfg, err := config.Load()
 	if err != nil {
-		log.Fatal(err)
+		logger.New(config.Config{}, os.Stdout).Error("failed to load config", "error", err)
+		os.Exit(1)
 	}
+
+	log := logger.New(cfg, os.Stdout)
 
 	srv := &http.Server{
 		Addr:              cfg.Addr,
@@ -24,7 +28,7 @@ func main() {
 		IdleTimeout:       120 * time.Second,
 	}
 
-	log.Printf("listening on %s (env: %s)", cfg.Addr, cfg.Env)
+	log.Info("server starting", "addr", cfg.Addr, "env", cfg.Env)
 
 	if cfg.TLSEnabled {
 		err = srv.ListenAndServeTLS(cfg.CertFile, cfg.KeyFile)
@@ -32,6 +36,7 @@ func main() {
 		err = srv.ListenAndServe()
 	}
 	if err != nil {
-		log.Fatal(err)
+		log.Error("server stopped", "error", err)
+		os.Exit(1)
 	}
 }

--- a/backend-go/cmd/api/main.go
+++ b/backend-go/cmd/api/main.go
@@ -10,7 +10,10 @@ import (
 )
 
 func main() {
-	cfg := config.Load()
+	cfg, err := config.Load()
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	srv := &http.Server{
 		Addr:              cfg.Addr,
@@ -23,7 +26,6 @@ func main() {
 
 	log.Printf("listening on %s (env: %s)", cfg.Addr, cfg.Env)
 
-	var err error
 	if cfg.TLSEnabled {
 		err = srv.ListenAndServeTLS(cfg.CertFile, cfg.KeyFile)
 	} else {

--- a/backend-go/go.mod
+++ b/backend-go/go.mod
@@ -3,6 +3,7 @@ module github.com/posiposi/dragons-counter/backend-go
 go 1.24.13
 
 require (
+	github.com/caarlos0/env/v11 v11.4.1
 	github.com/go-chi/chi/v5 v5.3.0
 	github.com/stretchr/testify v1.11.1
 )

--- a/backend-go/go.mod
+++ b/backend-go/go.mod
@@ -5,10 +5,12 @@ go 1.24.13
 require (
 	github.com/caarlos0/env/v11 v11.4.1
 	github.com/go-chi/chi/v5 v5.3.0
+	github.com/go-sql-driver/mysql v1.10.0
 	github.com/stretchr/testify v1.11.1
 )
 
 require (
+	filippo.io/edwards25519 v1.2.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/backend-go/go.sum
+++ b/backend-go/go.sum
@@ -1,3 +1,5 @@
+github.com/caarlos0/env/v11 v11.4.1 h1:fYwH0sWEsBSMPG7t4e/PEfTFzrWrpjyygXyUnWiSwEw=
+github.com/caarlos0/env/v11 v11.4.1/go.mod h1:qupehSf/Y0TUTsxKywqRt/vJjN5nz6vauiYEUUr8P4U=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-chi/chi/v5 v5.3.0 h1:halUjDxhshgXHMrao5bB8eNBXo/rnzwr8m5m36glehM=

--- a/backend-go/go.sum
+++ b/backend-go/go.sum
@@ -1,9 +1,13 @@
+filippo.io/edwards25519 v1.2.0 h1:crnVqOiS4jqYleHd9vaKZ+HKtHfllngJIiOpNpoJsjo=
+filippo.io/edwards25519 v1.2.0/go.mod h1:xzAOLCNug/yB62zG1bQ8uziwrIqIuxhctzJT18Q77mc=
 github.com/caarlos0/env/v11 v11.4.1 h1:fYwH0sWEsBSMPG7t4e/PEfTFzrWrpjyygXyUnWiSwEw=
 github.com/caarlos0/env/v11 v11.4.1/go.mod h1:qupehSf/Y0TUTsxKywqRt/vJjN5nz6vauiYEUUr8P4U=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-chi/chi/v5 v5.3.0 h1:halUjDxhshgXHMrao5bB8eNBXo/rnzwr8m5m36glehM=
 github.com/go-chi/chi/v5 v5.3.0/go.mod h1:R+tYY2hNuVUUjxoPtqUdgBqevM9s9njzkTLutVsOCto=
+github.com/go-sql-driver/mysql v1.10.0 h1:Q+1LV8DkHJvSYAdR83XzuhDaTykuDx0l6fkXxoWCWfw=
+github.com/go-sql-driver/mysql v1.10.0/go.mod h1:M+cqaI7+xxXGG9swrdeUIoPG3Y3KCkF0pZej+SK+nWk=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=

--- a/backend-go/internal/config/config.go
+++ b/backend-go/internal/config/config.go
@@ -43,7 +43,7 @@ func applyRuntimeMode(cfg *Config) {
 	goEnv := strings.ToLower(strings.TrimSpace(os.Getenv("GO_ENV")))
 	if goEnv == "production" {
 		cfg.Env = "production"
-		cfg.Addr = ":3000"
+		cfg.Addr = ":" + cfg.Port
 		cfg.TLSEnabled = false
 		cfg.CertFile = ""
 		cfg.KeyFile = ""
@@ -51,7 +51,7 @@ func applyRuntimeMode(cfg *Config) {
 	}
 
 	cfg.Env = "development"
-	cfg.Addr = ":3443"
+	cfg.Addr = ":" + cfg.HTTPSPort
 	cfg.TLSEnabled = true
 	cfg.CertFile = "certs/localhost.pem"
 	cfg.KeyFile = "certs/localhost-key.pem"

--- a/backend-go/internal/config/config.go
+++ b/backend-go/internal/config/config.go
@@ -3,6 +3,8 @@ package config
 import (
 	"os"
 	"strings"
+
+	"github.com/caarlos0/env/v11"
 )
 
 type Config struct {
@@ -11,24 +13,46 @@ type Config struct {
 	TLSEnabled bool
 	CertFile   string
 	KeyFile    string
+
+	DatabaseURL          string   `env:"DATABASE_URL"`
+	JWTSecret            string   `env:"JWT_SECRET"`
+	Port                 string   `env:"PORT" envDefault:"3000"`
+	HTTPSPort            string   `env:"HTTPS_PORT" envDefault:"3443"`
+	AllowedOrigins       []string `env:"ALLOWED_ORIGINS" envSeparator:","`
+	APIGatewayURL        string   `env:"API_GATEWAY_URL"`
+	APIGatewayAPIKey     string   `env:"API_GATEWAY_API_KEY"`
+	AWSRegion            string   `env:"AWS_REGION" envDefault:"ap-northeast-1"`
+	AdminEmail           string   `env:"ADMIN_EMAIL"`
+	AdminDefaultPassword string   `env:"ADMIN_DEFAULT_PASSWORD"`
 }
 
-func Load() Config {
-	env := strings.ToLower(strings.TrimSpace(os.Getenv("GO_ENV")))
-	if env == "production" {
-		return Config{
-			Env:        "production",
-			Addr:       ":3000",
-			TLSEnabled: false,
-			CertFile:   "",
-			KeyFile:    "",
-		}
+func Load() (Config, error) {
+	var cfg Config
+	if err := env.Parse(&cfg); err != nil {
+		return Config{}, err
 	}
-	return Config{
-		Env:        "development",
-		Addr:       ":3443",
-		TLSEnabled: true,
-		CertFile:   "certs/localhost.pem",
-		KeyFile:    "certs/localhost-key.pem",
+
+	applyRuntimeMode(&cfg)
+
+	return cfg, nil
+}
+
+// applyRuntimeMode はGO_ENVを正規化し、実行モードに応じた
+// リッスンアドレス・TLS設定・証明書パスを決定する。
+func applyRuntimeMode(cfg *Config) {
+	goEnv := strings.ToLower(strings.TrimSpace(os.Getenv("GO_ENV")))
+	if goEnv == "production" {
+		cfg.Env = "production"
+		cfg.Addr = ":3000"
+		cfg.TLSEnabled = false
+		cfg.CertFile = ""
+		cfg.KeyFile = ""
+		return
 	}
+
+	cfg.Env = "development"
+	cfg.Addr = ":3443"
+	cfg.TLSEnabled = true
+	cfg.CertFile = "certs/localhost.pem"
+	cfg.KeyFile = "certs/localhost-key.pem"
 }

--- a/backend-go/internal/config/config_test.go
+++ b/backend-go/internal/config/config_test.go
@@ -12,8 +12,9 @@ func TestLoad(t *testing.T) {
 	t.Run("GO_ENV=productionの場合はTLS無効でアドレス:3000の設定を返す", func(t *testing.T) {
 		t.Setenv("GO_ENV", "production")
 
-		cfg := Load()
+		cfg, err := Load()
 
+		require.NoError(t, err)
 		assert.Equal(t, "production", cfg.Env)
 		assert.Equal(t, ":3000", cfg.Addr)
 		assert.False(t, cfg.TLSEnabled)
@@ -24,8 +25,9 @@ func TestLoad(t *testing.T) {
 	t.Run("GO_ENV=PRODUCTION（大文字）の場合は小文字化によりproduction扱いの設定を返す", func(t *testing.T) {
 		t.Setenv("GO_ENV", "PRODUCTION")
 
-		cfg := Load()
+		cfg, err := Load()
 
+		require.NoError(t, err)
 		assert.Equal(t, "production", cfg.Env)
 		assert.Equal(t, ":3000", cfg.Addr)
 		assert.False(t, cfg.TLSEnabled)
@@ -36,8 +38,9 @@ func TestLoad(t *testing.T) {
 	t.Run("GO_ENVに前後空白がある場合はtrimによりproduction扱いの設定を返す", func(t *testing.T) {
 		t.Setenv("GO_ENV", " production ")
 
-		cfg := Load()
+		cfg, err := Load()
 
+		require.NoError(t, err)
 		assert.Equal(t, "production", cfg.Env)
 		assert.Equal(t, ":3000", cfg.Addr)
 		assert.False(t, cfg.TLSEnabled)
@@ -48,8 +51,9 @@ func TestLoad(t *testing.T) {
 	t.Run("GO_ENV=developmentの場合はTLS有効でアドレス:3443・証明書パスの設定を返す", func(t *testing.T) {
 		t.Setenv("GO_ENV", "development")
 
-		cfg := Load()
+		cfg, err := Load()
 
+		require.NoError(t, err)
 		assert.Equal(t, "development", cfg.Env)
 		assert.Equal(t, ":3443", cfg.Addr)
 		assert.True(t, cfg.TLSEnabled)
@@ -62,8 +66,9 @@ func TestLoad(t *testing.T) {
 		t.Setenv("GO_ENV", "")
 		require.NoError(t, os.Unsetenv("GO_ENV"))
 
-		cfg := Load()
+		cfg, err := Load()
 
+		require.NoError(t, err)
 		assert.Equal(t, "development", cfg.Env)
 		assert.Equal(t, ":3443", cfg.Addr)
 		assert.True(t, cfg.TLSEnabled)
@@ -74,12 +79,69 @@ func TestLoad(t *testing.T) {
 	t.Run("GO_ENVが想定外の値の場合はdevelopment扱いでTLS有効・アドレス:3443の設定を返す", func(t *testing.T) {
 		t.Setenv("GO_ENV", "staging")
 
-		cfg := Load()
+		cfg, err := Load()
 
+		require.NoError(t, err)
 		assert.Equal(t, "development", cfg.Env)
 		assert.Equal(t, ":3443", cfg.Addr)
 		assert.True(t, cfg.TLSEnabled)
 		assert.Equal(t, "certs/localhost.pem", cfg.CertFile)
 		assert.Equal(t, "certs/localhost-key.pem", cfg.KeyFile)
+	})
+}
+
+func TestLoadEnv(t *testing.T) {
+	t.Run("環境変数が設定されている場合はConfigの各フィールドへマッピングされる", func(t *testing.T) {
+		t.Setenv("DATABASE_URL", "mysql://user:pass@db:3306/dragons_counter")
+		t.Setenv("JWT_SECRET", "secret-value")
+		t.Setenv("PORT", "8080")
+		t.Setenv("HTTPS_PORT", "8443")
+		t.Setenv("ALLOWED_ORIGINS", "https://a.example.com,https://b.example.com")
+		t.Setenv("API_GATEWAY_URL", "https://gw.example.com")
+		t.Setenv("API_GATEWAY_API_KEY", "gw-key")
+		t.Setenv("AWS_REGION", "us-east-1")
+		t.Setenv("ADMIN_EMAIL", "admin@example.com")
+		t.Setenv("ADMIN_DEFAULT_PASSWORD", "admin-pass")
+
+		cfg, err := Load()
+
+		require.NoError(t, err)
+		assert.Equal(t, "mysql://user:pass@db:3306/dragons_counter", cfg.DatabaseURL)
+		assert.Equal(t, "secret-value", cfg.JWTSecret)
+		assert.Equal(t, "8080", cfg.Port)
+		assert.Equal(t, "8443", cfg.HTTPSPort)
+		assert.Equal(t, []string{"https://a.example.com", "https://b.example.com"}, cfg.AllowedOrigins)
+		assert.Equal(t, "https://gw.example.com", cfg.APIGatewayURL)
+		assert.Equal(t, "gw-key", cfg.APIGatewayAPIKey)
+		assert.Equal(t, "us-east-1", cfg.AWSRegion)
+		assert.Equal(t, "admin@example.com", cfg.AdminEmail)
+		assert.Equal(t, "admin-pass", cfg.AdminDefaultPassword)
+	})
+
+	t.Run("PORT・HTTPS_PORT・AWS_REGION未設定時はデフォルト値が入る", func(t *testing.T) {
+		for _, key := range []string{"PORT", "HTTPS_PORT", "AWS_REGION"} {
+			t.Setenv(key, "")
+			require.NoError(t, os.Unsetenv(key))
+		}
+
+		cfg, err := Load()
+
+		require.NoError(t, err)
+		assert.Equal(t, "3000", cfg.Port)
+		assert.Equal(t, "3443", cfg.HTTPSPort)
+		assert.Equal(t, "ap-northeast-1", cfg.AWSRegion)
+	})
+
+	t.Run("必須envが未設定でもLoadはエラーを返さずアプリ起動を継続できる", func(t *testing.T) {
+		for _, key := range []string{"DATABASE_URL", "JWT_SECRET"} {
+			t.Setenv(key, "")
+			require.NoError(t, os.Unsetenv(key))
+		}
+
+		cfg, err := Load()
+
+		require.NoError(t, err)
+		assert.Empty(t, cfg.DatabaseURL)
+		assert.Empty(t, cfg.JWTSecret)
 	})
 }

--- a/backend-go/internal/config/config_test.go
+++ b/backend-go/internal/config/config_test.go
@@ -144,4 +144,24 @@ func TestLoadEnv(t *testing.T) {
 		assert.Empty(t, cfg.DatabaseURL)
 		assert.Empty(t, cfg.JWTSecret)
 	})
+
+	t.Run("production環境ではPORTでリッスンアドレスが決まる", func(t *testing.T) {
+		t.Setenv("GO_ENV", "production")
+		t.Setenv("PORT", "8080")
+
+		cfg, err := Load()
+
+		require.NoError(t, err)
+		assert.Equal(t, ":8080", cfg.Addr)
+	})
+
+	t.Run("development環境ではHTTPS_PORTでリッスンアドレスが決まる", func(t *testing.T) {
+		t.Setenv("GO_ENV", "development")
+		t.Setenv("HTTPS_PORT", "8443")
+
+		cfg, err := Load()
+
+		require.NoError(t, err)
+		assert.Equal(t, ":8443", cfg.Addr)
+	})
 }

--- a/backend-go/internal/config/dsn.go
+++ b/backend-go/internal/config/dsn.go
@@ -1,0 +1,71 @@
+package config
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/go-sql-driver/mysql"
+)
+
+// BuildDSN は `mysql://user:pass@host:port/db?...` 形式のURLを
+// go-sql-driver/mysql が要求するDSN形式へ変換する。
+// 空文字・不正URL・非mysqlスキームの場合はエラーを返す。
+// parseTime はクエリで明示されない限り true をデフォルトで付与する。
+func BuildDSN(databaseURL string) (string, error) {
+	if databaseURL == "" {
+		return "", errors.New("DATABASE_URL is required")
+	}
+
+	u, err := url.Parse(databaseURL)
+	if err != nil {
+		return "", fmt.Errorf("invalid DATABASE_URL format: %w", err)
+	}
+	if u.Scheme != "mysql" {
+		return "", fmt.Errorf("invalid DATABASE_URL format: unsupported scheme %q", u.Scheme)
+	}
+
+	cfg := mysql.NewConfig()
+	cfg.User = u.User.Username()
+	if pw, ok := u.User.Password(); ok {
+		cfg.Passwd = pw
+	}
+	cfg.Net = "tcp"
+
+	port := u.Port()
+	if port == "" {
+		port = "3306"
+	}
+	cfg.Addr = net.JoinHostPort(u.Hostname(), port)
+	cfg.DBName = strings.TrimPrefix(u.Path, "/")
+	cfg.ParseTime = true
+
+	for key, values := range u.Query() {
+		if len(values) == 0 {
+			continue
+		}
+		value := values[0]
+		switch key {
+		case "parseTime":
+			cfg.ParseTime = value == "true"
+		case "loc":
+			loc, err := time.LoadLocation(value)
+			if err != nil {
+				return "", fmt.Errorf("invalid loc parameter: %w", err)
+			}
+			cfg.Loc = loc
+		case "collation":
+			cfg.Collation = value
+		default:
+			if cfg.Params == nil {
+				cfg.Params = map[string]string{}
+			}
+			cfg.Params[key] = value
+		}
+	}
+
+	return cfg.FormatDSN(), nil
+}

--- a/backend-go/internal/config/dsn_test.go
+++ b/backend-go/internal/config/dsn_test.go
@@ -1,0 +1,84 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/go-sql-driver/mysql"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildDSN(t *testing.T) {
+	t.Run("mysql://形式をgo-sql-driverのDSN形式へ変換しparseTime=trueを付与する", func(t *testing.T) {
+		dsn, err := BuildDSN("mysql://user:pass@db:3306/dragons_counter")
+
+		require.NoError(t, err)
+		assert.Equal(t, "user:pass@tcp(db:3306)/dragons_counter?parseTime=true", dsn)
+	})
+
+	t.Run("ポート未指定の場合は3306を補完する", func(t *testing.T) {
+		dsn, err := BuildDSN("mysql://user:pass@db/dragons_counter")
+
+		require.NoError(t, err)
+		assert.Equal(t, "user:pass@tcp(db:3306)/dragons_counter?parseTime=true", dsn)
+	})
+
+	t.Run("パスワードに特殊文字を含む場合も往復パースで元の値を復元できる", func(t *testing.T) {
+		// パスワードは p@ss:w/rd（@ : / を含む）をURLエンコードして渡す
+		dsn, err := BuildDSN("mysql://user:p%40ss%3Aw%2Frd@db:3306/dragons_counter")
+
+		require.NoError(t, err)
+
+		parsed, err := mysql.ParseDSN(dsn)
+		require.NoError(t, err)
+		assert.Equal(t, "user", parsed.User)
+		assert.Equal(t, "p@ss:w/rd", parsed.Passwd)
+		assert.Equal(t, "db:3306", parsed.Addr)
+		assert.Equal(t, "dragons_counter", parsed.DBName)
+		assert.True(t, parsed.ParseTime)
+	})
+
+	t.Run("クエリパラメータcharset・locを引き継ぎparseTimeを維持する", func(t *testing.T) {
+		dsn, err := BuildDSN("mysql://user:pass@db:3306/dragons_counter?charset=utf8mb4&loc=Asia%2FTokyo")
+
+		require.NoError(t, err)
+		// charset は生成DSN文字列へ引き継がれる
+		assert.Contains(t, dsn, "charset=utf8mb4")
+
+		parsed, err := mysql.ParseDSN(dsn)
+		require.NoError(t, err)
+		assert.Equal(t, "Asia/Tokyo", parsed.Loc.String())
+		assert.True(t, parsed.ParseTime)
+	})
+
+	t.Run("parseTime=falseがクエリで明示された場合はfalseを反映する", func(t *testing.T) {
+		dsn, err := BuildDSN("mysql://user:pass@db:3306/dragons_counter?parseTime=false")
+
+		require.NoError(t, err)
+
+		parsed, err := mysql.ParseDSN(dsn)
+		require.NoError(t, err)
+		assert.False(t, parsed.ParseTime)
+	})
+
+	t.Run("空文字の場合はDATABASE_URL is requiredエラーを返す", func(t *testing.T) {
+		_, err := BuildDSN("")
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "DATABASE_URL is required")
+	})
+
+	t.Run("mysql以外のスキームの場合はフォーマットエラーを返す", func(t *testing.T) {
+		_, err := BuildDSN("postgres://user:pass@db:5432/dragons_counter")
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid DATABASE_URL format")
+	})
+
+	t.Run("パースできない不正なURLの場合はフォーマットエラーを返す", func(t *testing.T) {
+		_, err := BuildDSN("://not-a-valid-url")
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid DATABASE_URL format")
+	})
+}

--- a/backend-go/internal/logger/logger.go
+++ b/backend-go/internal/logger/logger.go
@@ -1,0 +1,17 @@
+package logger
+
+import (
+	"io"
+	"log/slog"
+
+	"github.com/posiposi/dragons-counter/backend-go/internal/config"
+)
+
+// New は実行環境に応じた構造化ロガーを生成する。
+// production ではJSON、development では可読性の高いText形式で出力する。
+func New(cfg config.Config, w io.Writer) *slog.Logger {
+	if cfg.Env == "production" {
+		return slog.New(slog.NewJSONHandler(w, nil))
+	}
+	return slog.New(slog.NewTextHandler(w, nil))
+}

--- a/backend-go/internal/logger/logger_test.go
+++ b/backend-go/internal/logger/logger_test.go
@@ -1,0 +1,43 @@
+package logger
+
+import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"testing"
+
+	"github.com/posiposi/dragons-counter/backend-go/internal/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNew(t *testing.T) {
+	t.Run("production環境ではJSONハンドラのロガーを返し構造化ログを出力する", func(t *testing.T) {
+		var buf bytes.Buffer
+		l := New(config.Config{Env: "production"}, &buf)
+
+		_, ok := l.Handler().(*slog.JSONHandler)
+		assert.True(t, ok, "productionではJSONHandlerを使う")
+
+		l.Info("server starting", "addr", ":3000")
+
+		var record map[string]any
+		require.NoError(t, json.Unmarshal(buf.Bytes(), &record))
+		assert.Equal(t, "server starting", record["msg"])
+		assert.Equal(t, ":3000", record["addr"])
+	})
+
+	t.Run("development環境ではTextハンドラのロガーを返す", func(t *testing.T) {
+		var buf bytes.Buffer
+		l := New(config.Config{Env: "development"}, &buf)
+
+		_, ok := l.Handler().(*slog.TextHandler)
+		assert.True(t, ok, "developmentではTextHandlerを使う")
+
+		l.Info("server starting", "addr", ":3443")
+
+		out := buf.String()
+		assert.Contains(t, out, "msg=\"server starting\"")
+		assert.Contains(t, out, "addr=:3443")
+	})
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,6 +59,8 @@ services:
       dockerfile: Dockerfile
       target: development
     restart: always
+    env_file:
+      - ./.env
     environment:
       GO_ENV: development
     ports:


### PR DESCRIPTION
## 概要

Go移行 Phase 0（#188）の PR-03 として、backend-go に env読込・DATABASE_URL→DSN変換・構造化ログの基盤を実装しました。既存の Node バックエンドは無傷で、本PR単体で main マージ可能です。

Closes #196

## 変更内容

- `caarlos0/env` を導入し、Config構造体へ env（DATABASE_URL/JWT_SECRET/PORT/HTTPS_PORT/ALLOWED_ORIGINS/API_GATEWAY_*/AWS_REGION/ADMIN_* 等）をマッピング。`Load()` を `(Config, error)` 化（GO_ENV分岐の既存挙動は不変）
- `mysql://` URL を go-sql-driver DSN 形式へ変換する `BuildDSN` を追加（`mysql.Config`+`FormatDSN` で特殊文字を安全に処理、ポート欠落時3306補完、parseTime=true付与、charset/loc/collation 等のクエリ引き継ぎ、空/不正URL/非mysqlスキームはエラー）
- `internal/logger` を新設し `log/slog` による構造化ログを導入（production=JSON / development=Text）。`main.go` の標準log をslogへ置換
- docker-compose の backend-go サービスに `env_file: ./.env` を追加（値はcompose定義に露出せず .env に留まる）

### 補足

- 必須env検証は `Load()` では行わず DSN変換ヘルパー側（空/不正URLでエラー）に置き、現状の `/health` のみアプリを壊さない設計としています（実際のDB接続検証は PR-04/#197 スコープ）。

## テスト

- 単体テストを追加・実行済み（config: Load 9ケース / BuildDSN 8ケース、logger: 2ケース、全PASS）
- `go build` / `go vet` / `gofmt -l`（差分なし）を確認
- 回帰確認: backend-go 再起動で `/health` が `{"status":"ok"}` を返し、構造化ログ出力・DATABASE_URL未設定でも起動継続を確認