### PR TITLE
Go移行 Phase 1: User集約ドメイン（Email/Password/Userエンティティ）を実装

### DIFF
--- a/backend-go/go.mod
+++ b/backend-go/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/golang-migrate/migrate/v4 v4.19.1
 	github.com/google/uuid v1.6.0
 	github.com/stretchr/testify v1.11.1
+	golang.org/x/crypto v0.45.0
 )
 
 require (
@@ -46,7 +47,6 @@ require (
 	go.uber.org/atomic v1.11.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.0 // indirect
-	golang.org/x/crypto v0.45.0 // indirect
 	golang.org/x/exp v0.0.0-20250305212735-054e65f0b394 // indirect
 	golang.org/x/net v0.47.0 // indirect
 	golang.org/x/sync v0.18.0 // indirect

--- a/backend-go/internal/domain/user/email.go
+++ b/backend-go/internal/domain/user/email.go
@@ -1,0 +1,32 @@
+package user
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/posiposi/dragons-counter/backend-go/internal/domain"
+)
+
+var emailRegex = regexp.MustCompile(`^[^\s@]+@[^\s@]+\.[^\s@]+$`)
+
+type Email struct {
+	value string
+}
+
+func NewEmail(value string) (Email, error) {
+	if strings.TrimSpace(value) == "" {
+		return Email{}, domain.NewError("INVALID_EMAIL", "Email cannot be empty")
+	}
+	if !emailRegex.MatchString(value) {
+		return Email{}, domain.NewError("INVALID_EMAIL", "Invalid email format")
+	}
+	return Email{value: value}, nil
+}
+
+func (e Email) Value() string {
+	return e.value
+}
+
+func (e Email) Equals(other Email) bool {
+	return e.value == other.value
+}

--- a/backend-go/internal/domain/user/email_test.go
+++ b/backend-go/internal/domain/user/email_test.go
@@ -1,0 +1,89 @@
+package user_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/posiposi/dragons-counter/backend-go/internal/domain/user"
+)
+
+func TestNewEmail(t *testing.T) {
+	t.Run("有効なメールアドレスで生成できる", func(t *testing.T) {
+		tests := []struct {
+			name  string
+			value string
+		}{
+			{name: "通常の形式", value: "test@example.com"},
+			{name: "サブドメインを含む形式", value: "user@mail.example.co.jp"},
+			{name: "プラス記号を含む形式", value: "user+tag@example.com"},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				email, err := user.NewEmail(tt.value)
+
+				require.NoError(t, err)
+				assert.Equal(t, tt.value, email.Value())
+			})
+		}
+	})
+
+	t.Run("空文字の場合はエラーを返す", func(t *testing.T) {
+		tests := []struct {
+			name  string
+			value string
+		}{
+			{name: "空文字", value: ""},
+			{name: "空白のみ", value: "   "},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				_, err := user.NewEmail(tt.value)
+
+				require.Error(t, err)
+				assert.Equal(t, "Email cannot be empty", err.Error())
+			})
+		}
+	})
+
+	t.Run("不正な形式の場合はエラーを返す", func(t *testing.T) {
+		tests := []struct {
+			name  string
+			value string
+		}{
+			{name: "アットマークがない", value: "testexample.com"},
+			{name: "ドメインがない", value: "test@"},
+			{name: "ローカル部がない", value: "@example.com"},
+			{name: "空白を含む", value: "test user@example.com"},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				_, err := user.NewEmail(tt.value)
+
+				require.Error(t, err)
+				assert.Equal(t, "Invalid email format", err.Error())
+			})
+		}
+	})
+}
+
+func TestEmail_Equals(t *testing.T) {
+	t.Run("同じ値のEmail同士はtrueを返す", func(t *testing.T) {
+		a, err := user.NewEmail("test@example.com")
+		require.NoError(t, err)
+		b, err := user.NewEmail("test@example.com")
+		require.NoError(t, err)
+
+		assert.True(t, a.Equals(b))
+	})
+
+	t.Run("異なる値のEmail同士はfalseを返す", func(t *testing.T) {
+		a, err := user.NewEmail("test@example.com")
+		require.NoError(t, err)
+		b, err := user.NewEmail("other@example.com")
+		require.NoError(t, err)
+
+		assert.False(t, a.Equals(b))
+	})
+}

--- a/backend-go/internal/domain/user/id.go
+++ b/backend-go/internal/domain/user/id.go
@@ -1,0 +1,21 @@
+package user
+
+import (
+	"github.com/posiposi/dragons-counter/backend-go/internal/domain"
+)
+
+type UserID struct {
+	domain.ID
+}
+
+func NewUserID() UserID {
+	return UserID{ID: domain.NewID()}
+}
+
+func ParseUserID(value string) (UserID, error) {
+	id, err := domain.ParseID(value)
+	if err != nil {
+		return UserID{}, err
+	}
+	return UserID{ID: id}, nil
+}

--- a/backend-go/internal/domain/user/password.go
+++ b/backend-go/internal/domain/user/password.go
@@ -1,0 +1,41 @@
+package user
+
+import (
+	"strings"
+
+	"golang.org/x/crypto/bcrypt"
+
+	"github.com/posiposi/dragons-counter/backend-go/internal/domain"
+)
+
+const bcryptCost = 10
+
+type Password struct {
+	hash string
+}
+
+func NewPasswordFromPlainText(plainText string) (Password, error) {
+	if strings.TrimSpace(plainText) == "" {
+		return Password{}, domain.NewError("INVALID_PASSWORD", "Password cannot be empty")
+	}
+	hash, err := bcrypt.GenerateFromPassword([]byte(plainText), bcryptCost)
+	if err != nil {
+		return Password{}, err
+	}
+	return Password{hash: string(hash)}, nil
+}
+
+func NewPasswordFromHash(hash string) (Password, error) {
+	if strings.TrimSpace(hash) == "" {
+		return Password{}, domain.NewError("INVALID_PASSWORD", "Password hash cannot be empty")
+	}
+	return Password{hash: hash}, nil
+}
+
+func (p Password) Compare(plainText string) bool {
+	return bcrypt.CompareHashAndPassword([]byte(p.hash), []byte(plainText)) == nil
+}
+
+func (p Password) Hash() string {
+	return p.hash
+}

--- a/backend-go/internal/domain/user/password_test.go
+++ b/backend-go/internal/domain/user/password_test.go
@@ -1,0 +1,89 @@
+package user_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/bcrypt"
+
+	"github.com/posiposi/dragons-counter/backend-go/internal/domain/user"
+)
+
+func TestNewPasswordFromPlainText(t *testing.T) {
+	t.Run("空文字の場合はエラーを返す", func(t *testing.T) {
+		tests := []struct {
+			name  string
+			value string
+		}{
+			{name: "空文字", value: ""},
+			{name: "空白のみ", value: "   "},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				_, err := user.NewPasswordFromPlainText(tt.value)
+
+				require.Error(t, err)
+				assert.Equal(t, "Password cannot be empty", err.Error())
+			})
+		}
+	})
+}
+
+func TestNewPasswordFromHash(t *testing.T) {
+	t.Run("空文字の場合はエラーを返す", func(t *testing.T) {
+		tests := []struct {
+			name  string
+			value string
+		}{
+			{name: "空文字", value: ""},
+			{name: "空白のみ", value: "   "},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				_, err := user.NewPasswordFromHash(tt.value)
+
+				require.Error(t, err)
+				assert.Equal(t, "Password hash cannot be empty", err.Error())
+			})
+		}
+	})
+}
+
+func TestPassword_Compare(t *testing.T) {
+	t.Run("平文から生成したPasswordが同じ平文と一致する", func(t *testing.T) {
+		password, err := user.NewPasswordFromPlainText("SecurePass123!")
+		require.NoError(t, err)
+
+		assert.True(t, password.Compare("SecurePass123!"))
+	})
+
+	t.Run("平文から生成したPasswordが異なる平文と一致しない", func(t *testing.T) {
+		password, err := user.NewPasswordFromPlainText("SecurePass123!")
+		require.NoError(t, err)
+
+		assert.False(t, password.Compare("WrongPass456!"))
+	})
+
+	t.Run("ハッシュから復元したPasswordのCompareが機能する", func(t *testing.T) {
+		original, err := user.NewPasswordFromPlainText("SecurePass123!")
+		require.NoError(t, err)
+
+		restored, err := user.NewPasswordFromHash(original.Hash())
+		require.NoError(t, err)
+
+		assert.True(t, restored.Compare("SecurePass123!"))
+		assert.False(t, restored.Compare("WrongPass456!"))
+	})
+
+	t.Run("既知のbcryptハッシュから復元したPasswordが平文と照合できる", func(t *testing.T) {
+		hashBytes, err := bcrypt.GenerateFromPassword([]byte("StoredDbPass789!"), 10)
+		require.NoError(t, err)
+
+		password, err := user.NewPasswordFromHash(string(hashBytes))
+		require.NoError(t, err)
+
+		assert.True(t, password.Compare("StoredDbPass789!"))
+		assert.False(t, password.Compare("WrongPass456!"))
+	})
+}

--- a/backend-go/internal/domain/user/role.go
+++ b/backend-go/internal/domain/user/role.go
@@ -1,0 +1,8 @@
+package user
+
+type UserRole string
+
+const (
+	RoleUser  UserRole = "USER"
+	RoleAdmin UserRole = "ADMIN"
+)

--- a/backend-go/internal/domain/user/status.go
+++ b/backend-go/internal/domain/user/status.go
@@ -1,0 +1,10 @@
+package user
+
+type RegistrationStatus string
+
+const (
+	RegistrationStatusPending  RegistrationStatus = "PENDING"
+	RegistrationStatusApproved RegistrationStatus = "APPROVED"
+	RegistrationStatusRejected RegistrationStatus = "REJECTED"
+	RegistrationStatusBanned   RegistrationStatus = "BANNED"
+)

--- a/backend-go/internal/domain/user/user.go
+++ b/backend-go/internal/domain/user/user.go
@@ -1,0 +1,83 @@
+package user
+
+import (
+	"fmt"
+
+	"github.com/posiposi/dragons-counter/backend-go/internal/domain"
+)
+
+type User struct {
+	id                 UserID
+	email              Email
+	password           Password
+	registrationStatus RegistrationStatus
+	role               UserRole
+}
+
+func CreateNewUser(email Email, password Password) User {
+	return User{
+		id:                 NewUserID(),
+		email:              email,
+		password:           password,
+		registrationStatus: RegistrationStatusPending,
+		role:               RoleUser,
+	}
+}
+
+func UserFromRepository(
+	id UserID,
+	email Email,
+	password Password,
+	registrationStatus RegistrationStatus,
+	role UserRole,
+) User {
+	return User{
+		id:                 id,
+		email:              email,
+		password:           password,
+		registrationStatus: registrationStatus,
+		role:               role,
+	}
+}
+
+func (u User) ID() UserID {
+	return u.id
+}
+
+func (u User) Email() Email {
+	return u.email
+}
+
+func (u User) Password() Password {
+	return u.password
+}
+
+func (u User) RegistrationStatus() RegistrationStatus {
+	return u.registrationStatus
+}
+
+func (u User) Role() UserRole {
+	return u.role
+}
+
+func (u User) Approve() (User, error) {
+	return u.transitionTo(RegistrationStatusApproved)
+}
+
+func (u User) Reject() (User, error) {
+	return u.transitionTo(RegistrationStatusRejected)
+}
+
+func (u User) CanLogin() bool {
+	return u.registrationStatus == RegistrationStatusApproved
+}
+
+func (u User) transitionTo(next RegistrationStatus) (User, error) {
+	if u.registrationStatus != RegistrationStatusPending {
+		return User{}, domain.NewError(
+			"INVALID_STATUS_TRANSITION",
+			fmt.Sprintf("%sから%sへの遷移はできません", u.registrationStatus, next),
+		)
+	}
+	return UserFromRepository(u.id, u.email, u.password, next, u.role), nil
+}

--- a/backend-go/internal/domain/user/user_test.go
+++ b/backend-go/internal/domain/user/user_test.go
@@ -1,0 +1,160 @@
+package user_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/posiposi/dragons-counter/backend-go/internal/domain"
+	"github.com/posiposi/dragons-counter/backend-go/internal/domain/user"
+)
+
+func newTestEmailAndPassword(t *testing.T) (user.Email, user.Password) {
+	t.Helper()
+	email, err := user.NewEmail("test@example.com")
+	require.NoError(t, err)
+	password, err := user.NewPasswordFromHash("$2b$10$hashedpasswordvalue")
+	require.NoError(t, err)
+	return email, password
+}
+
+func TestParseUserID(t *testing.T) {
+	t.Run("有効な値でUserIDを生成できる", func(t *testing.T) {
+		id, err := user.ParseUserID("550e8400-e29b-41d4-a716-446655440000")
+
+		require.NoError(t, err)
+		assert.Equal(t, "550e8400-e29b-41d4-a716-446655440000", id.Value())
+	})
+}
+
+func TestCreateNewUser(t *testing.T) {
+	t.Run("PENDING状態かつUSERロールで新規ユーザーを生成できる", func(t *testing.T) {
+		email, password := newTestEmailAndPassword(t)
+
+		u := user.CreateNewUser(email, password)
+
+		assert.NotEmpty(t, u.ID().Value())
+		assert.Equal(t, email, u.Email())
+		assert.Equal(t, password, u.Password())
+		assert.Equal(t, user.RegistrationStatusPending, u.RegistrationStatus())
+		assert.Equal(t, user.RoleUser, u.Role())
+	})
+}
+
+func TestUserFromRepository(t *testing.T) {
+	t.Run("すべてのフィールドを指定してユーザーを復元できる", func(t *testing.T) {
+		email, password := newTestEmailAndPassword(t)
+		id := user.NewUserID()
+
+		u := user.UserFromRepository(id, email, password, user.RegistrationStatusApproved, user.RoleAdmin)
+
+		assert.Equal(t, id, u.ID())
+		assert.Equal(t, email, u.Email())
+		assert.Equal(t, password, u.Password())
+		assert.Equal(t, user.RegistrationStatusApproved, u.RegistrationStatus())
+		assert.Equal(t, user.RoleAdmin, u.Role())
+	})
+}
+
+func TestUser_CanLogin(t *testing.T) {
+	tests := []struct {
+		name   string
+		status user.RegistrationStatus
+		want   bool
+	}{
+		{name: "APPROVED状態の場合はtrueを返す", status: user.RegistrationStatusApproved, want: true},
+		{name: "PENDING状態の場合はfalseを返す", status: user.RegistrationStatusPending, want: false},
+		{name: "REJECTED状態の場合はfalseを返す", status: user.RegistrationStatusRejected, want: false},
+		{name: "BANNED状態の場合はfalseを返す", status: user.RegistrationStatusBanned, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			email, password := newTestEmailAndPassword(t)
+			u := user.UserFromRepository(user.NewUserID(), email, password, tt.status, user.RoleUser)
+
+			assert.Equal(t, tt.want, u.CanLogin())
+		})
+	}
+}
+
+func TestUser_Approve(t *testing.T) {
+	t.Run("PENDING状態からAPPROVED状態へ遷移できる", func(t *testing.T) {
+		email, password := newTestEmailAndPassword(t)
+		original := user.UserFromRepository(user.NewUserID(), email, password, user.RegistrationStatusPending, user.RoleUser)
+
+		approved, err := original.Approve()
+
+		require.NoError(t, err)
+		assert.Equal(t, user.RegistrationStatusApproved, approved.RegistrationStatus())
+		assert.Equal(t, original.ID(), approved.ID())
+		assert.Equal(t, user.RegistrationStatusPending, original.RegistrationStatus())
+	})
+
+	t.Run("PENDING以外の状態からはAPPROVEDへ遷移できずエラーを返す", func(t *testing.T) {
+		tests := []struct {
+			name    string
+			status  user.RegistrationStatus
+			message string
+		}{
+			{name: "APPROVED状態から", status: user.RegistrationStatusApproved, message: "APPROVEDからAPPROVEDへの遷移はできません"},
+			{name: "REJECTED状態から", status: user.RegistrationStatusRejected, message: "REJECTEDからAPPROVEDへの遷移はできません"},
+			{name: "BANNED状態から", status: user.RegistrationStatusBanned, message: "BANNEDからAPPROVEDへの遷移はできません"},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				email, password := newTestEmailAndPassword(t)
+				u := user.UserFromRepository(user.NewUserID(), email, password, tt.status, user.RoleUser)
+
+				_, err := u.Approve()
+
+				require.Error(t, err)
+				var domainErr *domain.Error
+				require.True(t, errors.As(err, &domainErr))
+				assert.Equal(t, "INVALID_STATUS_TRANSITION", domainErr.Code)
+				assert.Equal(t, tt.message, domainErr.Message)
+			})
+		}
+	})
+}
+
+func TestUser_Reject(t *testing.T) {
+	t.Run("PENDING状態からREJECTED状態へ遷移できる", func(t *testing.T) {
+		email, password := newTestEmailAndPassword(t)
+		original := user.UserFromRepository(user.NewUserID(), email, password, user.RegistrationStatusPending, user.RoleUser)
+
+		rejected, err := original.Reject()
+
+		require.NoError(t, err)
+		assert.Equal(t, user.RegistrationStatusRejected, rejected.RegistrationStatus())
+		assert.Equal(t, original.ID(), rejected.ID())
+		assert.Equal(t, user.RegistrationStatusPending, original.RegistrationStatus())
+	})
+
+	t.Run("PENDING以外の状態からはREJECTEDへ遷移できずエラーを返す", func(t *testing.T) {
+		tests := []struct {
+			name    string
+			status  user.RegistrationStatus
+			message string
+		}{
+			{name: "APPROVED状態から", status: user.RegistrationStatusApproved, message: "APPROVEDからREJECTEDへの遷移はできません"},
+			{name: "REJECTED状態から", status: user.RegistrationStatusRejected, message: "REJECTEDからREJECTEDへの遷移はできません"},
+			{name: "BANNED状態から", status: user.RegistrationStatusBanned, message: "BANNEDからREJECTEDへの遷移はできません"},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				email, password := newTestEmailAndPassword(t)
+				u := user.UserFromRepository(user.NewUserID(), email, password, tt.status, user.RoleUser)
+
+				_, err := u.Reject()
+
+				require.Error(t, err)
+				var domainErr *domain.Error
+				require.True(t, errors.As(err, &domainErr))
+				assert.Equal(t, "INVALID_STATUS_TRANSITION", domainErr.Code)
+				assert.Equal(t, tt.message, domainErr.Message)
+			})
+		}
+	})
+}


### PR DESCRIPTION
## 概要

Go移行 Phase 1（親Issue #189）の一環として、TypeScript版のUser集約を `backend-go/internal/domain/user/` パッケージへ移植しました。値オブジェクト（Email/Password/UserID）とUserエンティティ、登録ステータス・ロール定数を実装しています。

Closes #200

## 変更内容

- Email値オブジェクトを追加（正規表現 `^[^\s@]+@[^\s@]+\.[^\s@]+$` による形式検証）
- Password値オブジェクトを追加（bcrypt cost 10、`FromPlainText` / `FromHash` / `Compare`。実bcryptハッシュfixtureによる検証テストを含む）
- Userエンティティを追加
  - `CreateNewUser`: PENDING / USER を初期採番
  - `UserFromRepository`: 永続化データからの復元
  - `Approve` / `Reject`: PENDINGからのみ遷移可、違反時は `INVALID_STATUS_TRANSITION` エラー（イミュータブルに新インスタンスを返却）
  - `CanLogin`: APPROVEDのみtrue
- RegistrationStatus / UserRole 定数と UserID（共有 `domain.ID` 埋め込み）を追加
- `golang.org/x/crypto` をindirectから直接依存へ昇格

## テスト

- 単体テストを追加・実行済み（TDD: RED→GREEN）
- CLAUDE.mdのテスト方針に従い、enum値の存在確認やbcryptライブラリ挙動のみを検証するテストは作成していません

🤖 Generated with [Claude Code](https://claude.com/claude-code)