### PR TITLE
UserGame集約ドメインをGoへ移植

### DIFF
--- a/backend-go/internal/domain/usergame/id.go
+++ b/backend-go/internal/domain/usergame/id.go
@@ -1,0 +1,25 @@
+package usergame
+
+import (
+	"github.com/posiposi/dragons-counter/backend-go/internal/domain"
+)
+
+type UserGameID struct {
+	domain.ID
+}
+
+func NewUserGameID() UserGameID {
+	return UserGameID{ID: domain.NewID()}
+}
+
+func ParseUserGameID(value string) (UserGameID, error) {
+	id, err := domain.ParseID(value)
+	if err != nil {
+		return UserGameID{}, err
+	}
+	return UserGameID{ID: id}, nil
+}
+
+func (i UserGameID) Equals(other UserGameID) bool {
+	return i.ID.Equals(other.ID)
+}

--- a/backend-go/internal/domain/usergame/id_test.go
+++ b/backend-go/internal/domain/usergame/id_test.go
@@ -9,14 +9,6 @@ import (
 	"github.com/posiposi/dragons-counter/backend-go/internal/domain/usergame"
 )
 
-func TestNewUserGameID(t *testing.T) {
-	t.Run("非空のIDを採番する", func(t *testing.T) {
-		id := usergame.NewUserGameID()
-
-		assert.NotEmpty(t, id.Value())
-	})
-}
-
 func TestParseUserGameID(t *testing.T) {
 	t.Run("有効な文字列で生成できる", func(t *testing.T) {
 		id, err := usergame.ParseUserGameID("user-game-id-1")

--- a/backend-go/internal/domain/usergame/id_test.go
+++ b/backend-go/internal/domain/usergame/id_test.go
@@ -1,0 +1,47 @@
+package usergame_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/posiposi/dragons-counter/backend-go/internal/domain/usergame"
+)
+
+func TestNewUserGameID(t *testing.T) {
+	t.Run("非空のIDを採番する", func(t *testing.T) {
+		id := usergame.NewUserGameID()
+
+		assert.NotEmpty(t, id.Value())
+	})
+}
+
+func TestParseUserGameID(t *testing.T) {
+	t.Run("有効な文字列で生成できる", func(t *testing.T) {
+		id, err := usergame.ParseUserGameID("user-game-id-1")
+
+		require.NoError(t, err)
+		assert.Equal(t, "user-game-id-1", id.Value())
+	})
+}
+
+func TestUserGameIDEquals(t *testing.T) {
+	t.Run("同一値のIDが等価である", func(t *testing.T) {
+		id1, err := usergame.ParseUserGameID("user-game-id-1")
+		require.NoError(t, err)
+		id2, err := usergame.ParseUserGameID("user-game-id-1")
+		require.NoError(t, err)
+
+		assert.True(t, id1.Equals(id2))
+	})
+
+	t.Run("異なる値のIDが非等価である", func(t *testing.T) {
+		id1, err := usergame.ParseUserGameID("user-game-id-1")
+		require.NoError(t, err)
+		id2, err := usergame.ParseUserGameID("user-game-id-2")
+		require.NoError(t, err)
+
+		assert.False(t, id1.Equals(id2))
+	})
+}

--- a/backend-go/internal/domain/usergame/impression.go
+++ b/backend-go/internal/domain/usergame/impression.go
@@ -1,0 +1,48 @@
+package usergame
+
+import (
+	"strings"
+	"unicode/utf8"
+
+	"github.com/posiposi/dragons-counter/backend-go/internal/domain"
+)
+
+const impressionMaxLength = 191
+
+type Impression struct {
+	value string
+	empty bool
+}
+
+func NewImpression(value *string) (Impression, error) {
+	if value == nil {
+		return Impression{empty: true}, nil
+	}
+	trimmed := strings.TrimSpace(*value)
+	if trimmed == "" {
+		return Impression{empty: true}, nil
+	}
+	if utf8.RuneCountInString(trimmed) > impressionMaxLength {
+		return Impression{}, domain.NewError(
+			"INVALID_IMPRESSION",
+			"Impression must be 191 characters or less",
+		)
+	}
+	return Impression{value: trimmed}, nil
+}
+
+func (i Impression) Value() *string {
+	if i.empty {
+		return nil
+	}
+	value := i.value
+	return &value
+}
+
+func (i Impression) IsEmpty() bool {
+	return i.empty
+}
+
+func (i Impression) Equals(other Impression) bool {
+	return i == other
+}

--- a/backend-go/internal/domain/usergame/impression_test.go
+++ b/backend-go/internal/domain/usergame/impression_test.go
@@ -1,0 +1,107 @@
+package usergame_test
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/posiposi/dragons-counter/backend-go/internal/domain"
+	"github.com/posiposi/dragons-counter/backend-go/internal/domain/usergame"
+)
+
+func strPtr(s string) *string {
+	return &s
+}
+
+func TestNewImpression(t *testing.T) {
+	t.Run("有効な文字列で生成できる", func(t *testing.T) {
+		impression, err := usergame.NewImpression(strPtr("素晴らしい試合でした"))
+
+		require.NoError(t, err)
+		require.NotNil(t, impression.Value())
+		assert.Equal(t, "素晴らしい試合でした", *impression.Value())
+		assert.False(t, impression.IsEmpty())
+	})
+
+	t.Run("nilと空文字列は空として扱う", func(t *testing.T) {
+		fromNil, err := usergame.NewImpression(nil)
+		require.NoError(t, err)
+		assert.Nil(t, fromNil.Value())
+		assert.True(t, fromNil.IsEmpty())
+
+		fromEmpty, err := usergame.NewImpression(strPtr(""))
+		require.NoError(t, err)
+		assert.Nil(t, fromEmpty.Value())
+		assert.True(t, fromEmpty.IsEmpty())
+	})
+
+	t.Run("前後の空白をトリムする", func(t *testing.T) {
+		impression, err := usergame.NewImpression(strPtr("  感動した試合  "))
+
+		require.NoError(t, err)
+		require.NotNil(t, impression.Value())
+		assert.Equal(t, "感動した試合", *impression.Value())
+	})
+
+	t.Run("空白のみの文字列は空として扱う", func(t *testing.T) {
+		impression, err := usergame.NewImpression(strPtr("   "))
+
+		require.NoError(t, err)
+		assert.Nil(t, impression.Value())
+		assert.True(t, impression.IsEmpty())
+	})
+
+	t.Run("191文字を超える文字列でエラーになる", func(t *testing.T) {
+		longString := strings.Repeat("あ", 192)
+
+		_, err := usergame.NewImpression(strPtr(longString))
+
+		require.Error(t, err)
+		var domainErr *domain.Error
+		require.True(t, errors.As(err, &domainErr))
+		assert.Equal(t, "INVALID_IMPRESSION", domainErr.Code)
+		assert.Equal(t, "Impression must be 191 characters or less", domainErr.Message)
+	})
+
+	t.Run("191文字ちょうどの文字列で生成できる", func(t *testing.T) {
+		maxString := strings.Repeat("あ", 191)
+
+		impression, err := usergame.NewImpression(strPtr(maxString))
+
+		require.NoError(t, err)
+		require.NotNil(t, impression.Value())
+		assert.Equal(t, maxString, *impression.Value())
+	})
+}
+
+func TestImpressionEquals(t *testing.T) {
+	t.Run("空同士が等価である", func(t *testing.T) {
+		impression1, err := usergame.NewImpression(nil)
+		require.NoError(t, err)
+		impression2, err := usergame.NewImpression(strPtr(""))
+		require.NoError(t, err)
+
+		assert.True(t, impression1.Equals(impression2))
+	})
+
+	t.Run("値ありと空が非等価である", func(t *testing.T) {
+		impression1, err := usergame.NewImpression(strPtr("良い試合"))
+		require.NoError(t, err)
+		impression2, err := usergame.NewImpression(nil)
+		require.NoError(t, err)
+
+		assert.False(t, impression1.Equals(impression2))
+	})
+
+	t.Run("トリム後の値で等価性を比較する", func(t *testing.T) {
+		impression1, err := usergame.NewImpression(strPtr("  良い試合  "))
+		require.NoError(t, err)
+		impression2, err := usergame.NewImpression(strPtr("良い試合"))
+		require.NoError(t, err)
+
+		assert.True(t, impression1.Equals(impression2))
+	})
+}

--- a/backend-go/internal/domain/usergame/usergame.go
+++ b/backend-go/internal/domain/usergame/usergame.go
@@ -1,0 +1,83 @@
+package usergame
+
+import (
+	"time"
+
+	"github.com/posiposi/dragons-counter/backend-go/internal/domain"
+)
+
+type UserGame struct {
+	id         UserGameID
+	userID     domain.ID
+	gameID     domain.ID
+	impression Impression
+	createdAt  time.Time
+	updatedAt  time.Time
+}
+
+func CreateNewUserGame(userID, gameID domain.ID, impression Impression) UserGame {
+	now := time.Now()
+	return UserGame{
+		id:         NewUserGameID(),
+		userID:     userID,
+		gameID:     gameID,
+		impression: impression,
+		createdAt:  now,
+		updatedAt:  now,
+	}
+}
+
+func UserGameFromRepository(
+	id UserGameID,
+	userID, gameID domain.ID,
+	impression Impression,
+	createdAt, updatedAt time.Time,
+) UserGame {
+	return UserGame{
+		id:         id,
+		userID:     userID,
+		gameID:     gameID,
+		impression: impression,
+		createdAt:  createdAt,
+		updatedAt:  updatedAt,
+	}
+}
+
+func (u UserGame) ID() UserGameID {
+	return u.id
+}
+
+func (u UserGame) UserID() domain.ID {
+	return u.userID
+}
+
+func (u UserGame) GameID() domain.ID {
+	return u.gameID
+}
+
+func (u UserGame) Impression() Impression {
+	return u.impression
+}
+
+func (u UserGame) CreatedAt() time.Time {
+	return u.createdAt
+}
+
+func (u UserGame) UpdatedAt() time.Time {
+	return u.updatedAt
+}
+
+func (u UserGame) Equals(other UserGame) bool {
+	return u.id.Equals(other.id)
+}
+
+func (u UserGame) UpdateImpression(newImpression Impression) UserGame {
+	return UserGame{
+		id:         u.id,
+		userID:     u.userID,
+		gameID:     u.gameID,
+		impression: newImpression,
+		createdAt:  u.createdAt,
+		updatedAt:  time.Now(),
+	}
+}

--- a/backend-go/internal/domain/usergame/usergame_test.go
+++ b/backend-go/internal/domain/usergame/usergame_test.go
@@ -35,14 +35,6 @@ func newEmptyImpression(t *testing.T) usergame.Impression {
 }
 
 func TestCreateNewUserGame(t *testing.T) {
-	t.Run("IDが自動生成され空でない", func(t *testing.T) {
-		userID, gameID := newTestIDs(t)
-
-		userGame := usergame.CreateNewUserGame(userID, gameID, newEmptyImpression(t))
-
-		assert.NotEmpty(t, userGame.ID().Value())
-	})
-
 	t.Run("指定したuserIDとgameIDで作成できる", func(t *testing.T) {
 		userID, gameID := newTestIDs(t)
 

--- a/backend-go/internal/domain/usergame/usergame_test.go
+++ b/backend-go/internal/domain/usergame/usergame_test.go
@@ -1,0 +1,173 @@
+package usergame_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/posiposi/dragons-counter/backend-go/internal/domain"
+	"github.com/posiposi/dragons-counter/backend-go/internal/domain/usergame"
+)
+
+func newTestIDs(t *testing.T) (domain.ID, domain.ID) {
+	t.Helper()
+	userID, err := domain.ParseID("user-1")
+	require.NoError(t, err)
+	gameID, err := domain.ParseID("game-1")
+	require.NoError(t, err)
+	return userID, gameID
+}
+
+func newTestImpression(t *testing.T, value string) usergame.Impression {
+	t.Helper()
+	impression, err := usergame.NewImpression(&value)
+	require.NoError(t, err)
+	return impression
+}
+
+func newEmptyImpression(t *testing.T) usergame.Impression {
+	t.Helper()
+	impression, err := usergame.NewImpression(nil)
+	require.NoError(t, err)
+	return impression
+}
+
+func TestCreateNewUserGame(t *testing.T) {
+	t.Run("IDが自動生成され空でない", func(t *testing.T) {
+		userID, gameID := newTestIDs(t)
+
+		userGame := usergame.CreateNewUserGame(userID, gameID, newEmptyImpression(t))
+
+		assert.NotEmpty(t, userGame.ID().Value())
+	})
+
+	t.Run("指定したuserIDとgameIDで作成できる", func(t *testing.T) {
+		userID, gameID := newTestIDs(t)
+
+		userGame := usergame.CreateNewUserGame(userID, gameID, newEmptyImpression(t))
+
+		assert.True(t, userGame.UserID().Equals(userID))
+		assert.True(t, userGame.GameID().Equals(gameID))
+	})
+
+	t.Run("空のImpressionで作成するとImpressionが空になる", func(t *testing.T) {
+		userID, gameID := newTestIDs(t)
+
+		userGame := usergame.CreateNewUserGame(userID, gameID, newEmptyImpression(t))
+
+		assert.True(t, userGame.Impression().IsEmpty())
+	})
+
+	t.Run("Impressionありで作成できる", func(t *testing.T) {
+		userID, gameID := newTestIDs(t)
+		impression := newTestImpression(t, "素晴らしい試合でした")
+
+		userGame := usergame.CreateNewUserGame(userID, gameID, impression)
+
+		assert.True(t, userGame.Impression().Equals(impression))
+	})
+
+	t.Run("作成時にcreatedAtとupdatedAtが現在時刻で設定される", func(t *testing.T) {
+		userID, gameID := newTestIDs(t)
+
+		before := time.Now()
+		userGame := usergame.CreateNewUserGame(userID, gameID, newEmptyImpression(t))
+		after := time.Now()
+
+		assert.Equal(t, userGame.CreatedAt(), userGame.UpdatedAt())
+		assert.False(t, userGame.CreatedAt().Before(before))
+		assert.False(t, userGame.CreatedAt().After(after))
+	})
+}
+
+func TestUserGameFromRepository(t *testing.T) {
+	t.Run("すべてのフィールドを復元できる", func(t *testing.T) {
+		id := usergame.NewUserGameID()
+		userID, gameID := newTestIDs(t)
+		impression := newTestImpression(t, "良い試合")
+		createdAt := time.Date(2026, 1, 1, 10, 0, 0, 0, time.UTC)
+		updatedAt := time.Date(2026, 1, 2, 12, 30, 0, 0, time.UTC)
+
+		userGame := usergame.UserGameFromRepository(id, userID, gameID, impression, createdAt, updatedAt)
+
+		assert.True(t, userGame.ID().Equals(id))
+		assert.True(t, userGame.UserID().Equals(userID))
+		assert.True(t, userGame.GameID().Equals(gameID))
+		assert.True(t, userGame.Impression().Equals(impression))
+		assert.Equal(t, createdAt, userGame.CreatedAt())
+		assert.Equal(t, updatedAt, userGame.UpdatedAt())
+	})
+}
+
+func TestUserGameEquals(t *testing.T) {
+	t.Run("IDが同一なら他フィールドが異なっても等価である", func(t *testing.T) {
+		id := usergame.NewUserGameID()
+		userID, gameID := newTestIDs(t)
+		otherUserID, err := domain.ParseID("user-2")
+		require.NoError(t, err)
+		createdAt := time.Date(2026, 1, 1, 10, 0, 0, 0, time.UTC)
+
+		userGame1 := usergame.UserGameFromRepository(
+			id, userID, gameID, newTestImpression(t, "良い試合"), createdAt, createdAt,
+		)
+		userGame2 := usergame.UserGameFromRepository(
+			id, otherUserID, gameID, newEmptyImpression(t), createdAt.Add(time.Hour), createdAt.Add(time.Hour),
+		)
+
+		assert.True(t, userGame1.Equals(userGame2))
+	})
+
+	t.Run("IDが異なると非等価である", func(t *testing.T) {
+		userID, gameID := newTestIDs(t)
+		impression := newEmptyImpression(t)
+
+		userGame1 := usergame.CreateNewUserGame(userID, gameID, impression)
+		userGame2 := usergame.CreateNewUserGame(userID, gameID, impression)
+
+		assert.False(t, userGame1.Equals(userGame2))
+	})
+}
+
+func TestUserGameUpdateImpression(t *testing.T) {
+	t.Run("新しいImpressionを持つ新インスタンスを返す", func(t *testing.T) {
+		userID, gameID := newTestIDs(t)
+		original := usergame.CreateNewUserGame(userID, gameID, newTestImpression(t, "最初の感想"))
+		newImpression := newTestImpression(t, "更新後の感想")
+
+		updated := original.UpdateImpression(newImpression)
+
+		assert.True(t, updated.Impression().Equals(newImpression))
+	})
+
+	t.Run("元のインスタンスのImpressionは変更されない", func(t *testing.T) {
+		userID, gameID := newTestIDs(t)
+		originalImpression := newTestImpression(t, "最初の感想")
+		original := usergame.CreateNewUserGame(userID, gameID, originalImpression)
+
+		original.UpdateImpression(newTestImpression(t, "更新後の感想"))
+
+		assert.True(t, original.Impression().Equals(originalImpression))
+	})
+
+	t.Run("更新後もIDが維持される", func(t *testing.T) {
+		userID, gameID := newTestIDs(t)
+		original := usergame.CreateNewUserGame(userID, gameID, newEmptyImpression(t))
+
+		updated := original.UpdateImpression(newTestImpression(t, "更新後の感想"))
+
+		assert.True(t, original.Equals(updated))
+		assert.True(t, updated.ID().Equals(original.ID()))
+	})
+
+	t.Run("更新後のupdatedAtは元のupdatedAt以降の時刻になる", func(t *testing.T) {
+		userID, gameID := newTestIDs(t)
+		original := usergame.CreateNewUserGame(userID, gameID, newEmptyImpression(t))
+
+		updated := original.UpdateImpression(newTestImpression(t, "更新後の感想"))
+
+		assert.Equal(t, original.CreatedAt(), updated.CreatedAt())
+		assert.False(t, updated.UpdatedAt().Before(original.UpdatedAt()))
+	})
+}


### PR DESCRIPTION
## 概要

Go移行 Phase 1（親Issue #189）の一環として、TypeScript実装のUserGame集約を `backend-go/internal/domain/usergame/` パッケージへ移植しました。値オブジェクト（Impression・UserGameID）とUserGameエンティティを、TSスペックを1:1移植したテストとともにTDD（RED→GREEN）で実装しています。

Closes #201

## 変更内容

- `Impression` 値オブジェクトを追加（191文字制限はruneカウントで判定、nil・空文字・空白のみは空として正規化、trimした値を保持）
- `UserGameID` 値オブジェクトを追加（共有 `domain.ID` を埋め込み、UUID採番・Parseに対応）
- `UserGame` エンティティを追加
  - `CreateNewUserGame`: UUID採番、createdAt/updatedAtの自動設定
  - `UserGameFromRepository`: 永続化データからの再構築
  - `UpdateImpression`: イミュータブルな更新でupdatedAtを刷新
  - `Equals`: ID比較による等価判定
- 設計方針（Issue #201にコメント済み）: userId/gameId参照は共有 `domain.ID` 基底型で保持し、game/userパッケージをimportしない依存整理により PR-06/PR-07 との並列開発を可能にした

## テスト

- 単体テストを追加・実行済み（TSスペックを1:1移植、TDDのRED→GREENで実装）

🤖 Generated with [Claude Code](https://claude.com/claude-code)