### PR TITLE
Game集約のドメイン層をGoへ移植

### DIFF
--- a/backend-go/internal/domain/game/game.go
+++ b/backend-go/internal/domain/game/game.go
@@ -1,0 +1,78 @@
+package game
+
+import "time"
+
+type Game struct {
+	id            GameID
+	gameDate      GameDate
+	opponent      Opponent
+	dragonsScore  Score
+	opponentScore Score
+	result        GameResult
+	stadium       Stadium
+	createdAt     time.Time
+	updatedAt     time.Time
+}
+
+func NewGame(
+	id GameID,
+	gameDate GameDate,
+	opponent Opponent,
+	dragonsScore Score,
+	opponentScore Score,
+	stadium Stadium,
+	createdAt time.Time,
+	updatedAt time.Time,
+) Game {
+	return Game{
+		id:            id,
+		gameDate:      gameDate,
+		opponent:      opponent,
+		dragonsScore:  dragonsScore,
+		opponentScore: opponentScore,
+		result:        NewGameResultFromScores(dragonsScore.Value(), opponentScore.Value()),
+		stadium:       stadium,
+		createdAt:     createdAt,
+		updatedAt:     updatedAt,
+	}
+}
+
+func (g Game) ID() GameID {
+	return g.id
+}
+
+func (g Game) GameDate() GameDate {
+	return g.gameDate
+}
+
+func (g Game) Opponent() Opponent {
+	return g.opponent
+}
+
+func (g Game) DragonsScore() Score {
+	return g.dragonsScore
+}
+
+func (g Game) OpponentScore() Score {
+	return g.opponentScore
+}
+
+func (g Game) Result() GameResult {
+	return g.result
+}
+
+func (g Game) Stadium() Stadium {
+	return g.stadium
+}
+
+func (g Game) CreatedAt() time.Time {
+	return g.createdAt
+}
+
+func (g Game) UpdatedAt() time.Time {
+	return g.updatedAt
+}
+
+func (g Game) IsVictory() bool {
+	return g.result.IsWin()
+}

--- a/backend-go/internal/domain/game/game_test.go
+++ b/backend-go/internal/domain/game/game_test.go
@@ -1,0 +1,143 @@
+package game_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/posiposi/dragons-counter/backend-go/internal/domain/game"
+)
+
+type gameFixture struct {
+	id            game.GameID
+	gameDate      game.GameDate
+	opponent      game.Opponent
+	dragonsScore  game.Score
+	opponentScore game.Score
+	stadium       game.Stadium
+	createdAt     time.Time
+	updatedAt     time.Time
+}
+
+func newGameFixture(t *testing.T, dragonsScore, opponentScore int) gameFixture {
+	t.Helper()
+
+	gameDate, err := game.NewGameDate(time.Date(2024, 4, 1, 0, 0, 0, 0, time.UTC))
+	require.NoError(t, err)
+
+	opponent, err := game.NewOpponent("阪神タイガース")
+	require.NoError(t, err)
+
+	dScore, err := game.NewScore(dragonsScore)
+	require.NoError(t, err)
+
+	oScore, err := game.NewScore(opponentScore)
+	require.NoError(t, err)
+
+	stadiumName, err := game.NewStadiumName("バンテリンドーム ナゴヤ")
+	require.NoError(t, err)
+
+	return gameFixture{
+		id:            game.NewGameID(),
+		gameDate:      gameDate,
+		opponent:      opponent,
+		dragonsScore:  dScore,
+		opponentScore: oScore,
+		stadium:       game.NewStadium(game.NewStadiumID(), stadiumName),
+		createdAt:     time.Date(2024, 4, 1, 21, 0, 0, 0, time.UTC),
+		updatedAt:     time.Date(2024, 4, 2, 9, 0, 0, 0, time.UTC),
+	}
+}
+
+func TestNewGame(t *testing.T) {
+	t.Run("有効な値でGameを生成し各フィールドをゲッターで取得できる", func(t *testing.T) {
+		f := newGameFixture(t, 7, 3)
+
+		g := game.NewGame(
+			f.id,
+			f.gameDate,
+			f.opponent,
+			f.dragonsScore,
+			f.opponentScore,
+			f.stadium,
+			f.createdAt,
+			f.updatedAt,
+		)
+
+		assert.True(t, g.ID().Equals(f.id))
+		assert.Equal(t, f.gameDate, g.GameDate())
+		assert.True(t, g.Opponent().Equals(f.opponent))
+		assert.True(t, g.DragonsScore().Equals(f.dragonsScore))
+		assert.True(t, g.OpponentScore().Equals(f.opponentScore))
+		assert.True(t, g.Stadium().Equals(f.stadium))
+		assert.Equal(t, f.createdAt, g.CreatedAt())
+		assert.Equal(t, f.updatedAt, g.UpdatedAt())
+		assert.Equal(t, game.Win, g.Result().Value())
+	})
+}
+
+func TestNewGame_ResultDetermination(t *testing.T) {
+	tests := []struct {
+		name          string
+		dragonsScore  int
+		opponentScore int
+		expected      game.GameResultValue
+	}{
+		{name: "ドラゴンズの得点が多い場合はresultがWINになる", dragonsScore: 7, opponentScore: 3, expected: game.Win},
+		{name: "相手の得点が多い場合はresultがLOSEになる", dragonsScore: 2, opponentScore: 5, expected: game.Lose},
+		{name: "同点の場合はresultがDRAWになる", dragonsScore: 4, opponentScore: 4, expected: game.Draw},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := newGameFixture(t, tt.dragonsScore, tt.opponentScore)
+
+			g := game.NewGame(
+				f.id,
+				f.gameDate,
+				f.opponent,
+				f.dragonsScore,
+				f.opponentScore,
+				f.stadium,
+				f.createdAt,
+				f.updatedAt,
+			)
+
+			assert.Equal(t, tt.expected, g.Result().Value())
+		})
+	}
+}
+
+func TestGame_IsVictory(t *testing.T) {
+	tests := []struct {
+		name          string
+		dragonsScore  int
+		opponentScore int
+		expected      bool
+	}{
+		{name: "勝ちの場合はtrueを返す", dragonsScore: 7, opponentScore: 3, expected: true},
+		{name: "負けの場合はfalseを返す", dragonsScore: 2, opponentScore: 5, expected: false},
+		{name: "引き分けの場合はfalseを返す", dragonsScore: 4, opponentScore: 4, expected: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := newGameFixture(t, tt.dragonsScore, tt.opponentScore)
+
+			g := game.NewGame(
+				f.id,
+				f.gameDate,
+				f.opponent,
+				f.dragonsScore,
+				f.opponentScore,
+				f.stadium,
+				f.createdAt,
+				f.updatedAt,
+			)
+
+			assert.Equal(t, tt.expected, g.IsVictory())
+		})
+	}
+}

--- a/backend-go/internal/domain/game/gamedate.go
+++ b/backend-go/internal/domain/game/gamedate.go
@@ -1,0 +1,26 @@
+package game
+
+import (
+	"time"
+
+	"github.com/posiposi/dragons-counter/backend-go/internal/domain"
+)
+
+type GameDate struct {
+	value time.Time
+}
+
+func NewGameDate(value time.Time) (GameDate, error) {
+	if value.After(time.Now()) {
+		return GameDate{}, domain.NewError("INVALID_GAME_DATE", "Game date cannot be in the future")
+	}
+	return GameDate{value: value}, nil
+}
+
+func (g GameDate) Value() time.Time {
+	return g.value
+}
+
+func (g GameDate) Format() string {
+	return g.value.Format("2006-01-02")
+}

--- a/backend-go/internal/domain/game/gamedate_test.go
+++ b/backend-go/internal/domain/game/gamedate_test.go
@@ -1,0 +1,82 @@
+package game_test
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/posiposi/dragons-counter/backend-go/internal/domain"
+	"github.com/posiposi/dragons-counter/backend-go/internal/domain/game"
+)
+
+func TestNewGameDate(t *testing.T) {
+	t.Run("過去の日時で試合日を生成できる", func(t *testing.T) {
+		value := time.Date(2024, 8, 1, 18, 0, 0, 0, time.Local)
+
+		gameDate, err := game.NewGameDate(value)
+
+		require.NoError(t, err)
+		assert.True(t, gameDate.Value().Equal(value))
+	})
+
+	t.Run("現在時刻の直前の日時で試合日を生成できる", func(t *testing.T) {
+		value := time.Now().Add(-time.Second)
+
+		gameDate, err := game.NewGameDate(value)
+
+		require.NoError(t, err)
+		assert.True(t, gameDate.Value().Equal(value))
+	})
+
+	t.Run("未来の日時の場合はドメインエラーを返す", func(t *testing.T) {
+		value := time.Now().AddDate(0, 0, 1)
+
+		_, err := game.NewGameDate(value)
+
+		require.Error(t, err)
+		var domainErr *domain.Error
+		require.True(t, errors.As(err, &domainErr))
+		assert.NotEmpty(t, domainErr.Code)
+	})
+}
+
+func TestGameDate_Format(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    time.Time
+		expected string
+	}{
+		{
+			name:     "2024年8月1日をYYYY-MM-DD形式で整形できる",
+			value:    time.Date(2024, 8, 1, 18, 0, 0, 0, time.Local),
+			expected: "2024-08-01",
+		},
+		{
+			name:     "2024年1月5日をYYYY-MM-DD形式で整形できる",
+			value:    time.Date(2024, 1, 5, 13, 30, 0, 0, time.Local),
+			expected: "2024-01-05",
+		},
+		{
+			name:     "2024年12月31日をYYYY-MM-DD形式で整形できる",
+			value:    time.Date(2024, 12, 31, 0, 0, 0, 0, time.Local),
+			expected: "2024-12-31",
+		},
+		{
+			name:     "2024年10月10日をYYYY-MM-DD形式で整形できる",
+			value:    time.Date(2024, 10, 10, 14, 0, 0, 0, time.Local),
+			expected: "2024-10-10",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gameDate, err := game.NewGameDate(tt.value)
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.expected, gameDate.Format())
+		})
+	}
+}

--- a/backend-go/internal/domain/game/gameresult.go
+++ b/backend-go/internal/domain/game/gameresult.go
@@ -1,0 +1,32 @@
+package game
+
+type GameResultValue string
+
+const (
+	Win  GameResultValue = "WIN"
+	Lose GameResultValue = "LOSE"
+	Draw GameResultValue = "DRAW"
+)
+
+type GameResult struct {
+	value GameResultValue
+}
+
+func NewGameResultFromScores(dragonsScore, opponentScore int) GameResult {
+	switch {
+	case dragonsScore > opponentScore:
+		return GameResult{value: Win}
+	case opponentScore > dragonsScore:
+		return GameResult{value: Lose}
+	default:
+		return GameResult{value: Draw}
+	}
+}
+
+func (r GameResult) Value() GameResultValue {
+	return r.value
+}
+
+func (r GameResult) IsWin() bool {
+	return r.value == Win
+}

--- a/backend-go/internal/domain/game/gameresult_test.go
+++ b/backend-go/internal/domain/game/gameresult_test.go
@@ -1,0 +1,54 @@
+package game_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/posiposi/dragons-counter/backend-go/internal/domain/game"
+)
+
+func TestNewGameResultFromScores(t *testing.T) {
+	tests := []struct {
+		name          string
+		dragonsScore  int
+		opponentScore int
+		expected      game.GameResultValue
+	}{
+		{name: "ドラゴンズの得点が多い場合はWINを返す", dragonsScore: 5, opponentScore: 3, expected: game.Win},
+		{name: "相手の得点が多い場合はLOSEを返す", dragonsScore: 2, opponentScore: 4, expected: game.Lose},
+		{name: "同点の場合はDRAWを返す", dragonsScore: 3, opponentScore: 3, expected: game.Draw},
+		{name: "大差で勝った場合はWINを返す", dragonsScore: 10, opponentScore: 0, expected: game.Win},
+		{name: "大差で負けた場合はLOSEを返す", dragonsScore: 0, opponentScore: 10, expected: game.Lose},
+		{name: "0対0の場合はDRAWを返す", dragonsScore: 0, opponentScore: 0, expected: game.Draw},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := game.NewGameResultFromScores(tt.dragonsScore, tt.opponentScore)
+
+			assert.Equal(t, tt.expected, result.Value())
+		})
+	}
+}
+
+func TestGameResult_IsWin(t *testing.T) {
+	tests := []struct {
+		name          string
+		dragonsScore  int
+		opponentScore int
+		expected      bool
+	}{
+		{name: "WINの場合はtrueを返す", dragonsScore: 5, opponentScore: 3, expected: true},
+		{name: "LOSEの場合はfalseを返す", dragonsScore: 2, opponentScore: 4, expected: false},
+		{name: "DRAWの場合はfalseを返す", dragonsScore: 3, opponentScore: 3, expected: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := game.NewGameResultFromScores(tt.dragonsScore, tt.opponentScore)
+
+			assert.Equal(t, tt.expected, result.IsWin())
+		})
+	}
+}

--- a/backend-go/internal/domain/game/id.go
+++ b/backend-go/internal/domain/game/id.go
@@ -1,0 +1,45 @@
+package game
+
+import (
+	"github.com/posiposi/dragons-counter/backend-go/internal/domain"
+)
+
+type GameID struct {
+	domain.ID
+}
+
+func NewGameID() GameID {
+	return GameID{ID: domain.NewID()}
+}
+
+func ParseGameID(value string) (GameID, error) {
+	id, err := domain.ParseID(value)
+	if err != nil {
+		return GameID{}, err
+	}
+	return GameID{ID: id}, nil
+}
+
+func (g GameID) Equals(other GameID) bool {
+	return g.ID.Equals(other.ID)
+}
+
+type StadiumID struct {
+	domain.ID
+}
+
+func NewStadiumID() StadiumID {
+	return StadiumID{ID: domain.NewID()}
+}
+
+func ParseStadiumID(value string) (StadiumID, error) {
+	id, err := domain.ParseID(value)
+	if err != nil {
+		return StadiumID{}, err
+	}
+	return StadiumID{ID: id}, nil
+}
+
+func (s StadiumID) Equals(other StadiumID) bool {
+	return s.ID.Equals(other.ID)
+}

--- a/backend-go/internal/domain/game/opponent.go
+++ b/backend-go/internal/domain/game/opponent.go
@@ -1,0 +1,45 @@
+package game
+
+import (
+	"strings"
+
+	"github.com/posiposi/dragons-counter/backend-go/internal/domain"
+)
+
+var teamNameByAbbreviation = map[string]string{
+	"巨":  "読売ジャイアンツ",
+	"神":  "阪神タイガース",
+	"広":  "広島東洋カープ",
+	"De": "横浜DeNAベイスターズ",
+	"ヤ":  "東京ヤクルトスワローズ",
+	"中":  "中日ドラゴンズ",
+	"オ":  "オリックス・バファローズ",
+	"ソ":  "福岡ソフトバンクホークス",
+	"楽":  "東北楽天ゴールデンイーグルス",
+	"西":  "埼玉西武ライオンズ",
+	"ロ":  "千葉ロッテマリーンズ",
+	"日":  "北海道日本ハムファイターズ",
+}
+
+type Opponent struct {
+	value string
+}
+
+func NewOpponent(value string) (Opponent, error) {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return Opponent{}, domain.NewError("INVALID_OPPONENT", "Opponent name cannot be empty")
+	}
+	if fullName, ok := teamNameByAbbreviation[trimmed]; ok {
+		return Opponent{value: fullName}, nil
+	}
+	return Opponent{value: trimmed}, nil
+}
+
+func (o Opponent) Value() string {
+	return o.value
+}
+
+func (o Opponent) Equals(other Opponent) bool {
+	return o.value == other.value
+}

--- a/backend-go/internal/domain/game/opponent_test.go
+++ b/backend-go/internal/domain/game/opponent_test.go
@@ -1,0 +1,117 @@
+package game_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/posiposi/dragons-counter/backend-go/internal/domain"
+	"github.com/posiposi/dragons-counter/backend-go/internal/domain/game"
+)
+
+func TestNewOpponent(t *testing.T) {
+	t.Run("正式名称をそのまま保持できる", func(t *testing.T) {
+		opponent, err := game.NewOpponent("読売ジャイアンツ")
+
+		require.NoError(t, err)
+		assert.Equal(t, "読売ジャイアンツ", opponent.Value())
+	})
+
+	t.Run("英語名をそのまま保持できる", func(t *testing.T) {
+		opponent, err := game.NewOpponent("Yomiuri Giants")
+
+		require.NoError(t, err)
+		assert.Equal(t, "Yomiuri Giants", opponent.Value())
+	})
+
+	t.Run("空文字または空白のみの場合はドメインエラーを返す", func(t *testing.T) {
+		tests := []struct {
+			name  string
+			value string
+		}{
+			{name: "空文字はエラーになる", value: ""},
+			{name: "空白のみはエラーになる", value: "   "},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				_, err := game.NewOpponent(tt.value)
+
+				require.Error(t, err)
+				var domainErr *domain.Error
+				require.True(t, errors.As(err, &domainErr))
+				assert.NotEmpty(t, domainErr.Code)
+			})
+		}
+	})
+
+	t.Run("前後の空白を除去して保持する", func(t *testing.T) {
+		opponent, err := game.NewOpponent("  読売ジャイアンツ  ")
+
+		require.NoError(t, err)
+		assert.Equal(t, "読売ジャイアンツ", opponent.Value())
+	})
+
+	t.Run("12球団の略称を正式名称に変換できる", func(t *testing.T) {
+		tests := []struct {
+			name         string
+			abbreviation string
+			expected     string
+		}{
+			{name: "巨は読売ジャイアンツに変換される", abbreviation: "巨", expected: "読売ジャイアンツ"},
+			{name: "神は阪神タイガースに変換される", abbreviation: "神", expected: "阪神タイガース"},
+			{name: "広は広島東洋カープに変換される", abbreviation: "広", expected: "広島東洋カープ"},
+			{name: "Deは横浜DeNAベイスターズに変換される", abbreviation: "De", expected: "横浜DeNAベイスターズ"},
+			{name: "ヤは東京ヤクルトスワローズに変換される", abbreviation: "ヤ", expected: "東京ヤクルトスワローズ"},
+			{name: "中は中日ドラゴンズに変換される", abbreviation: "中", expected: "中日ドラゴンズ"},
+			{name: "オはオリックス・バファローズに変換される", abbreviation: "オ", expected: "オリックス・バファローズ"},
+			{name: "ソは福岡ソフトバンクホークスに変換される", abbreviation: "ソ", expected: "福岡ソフトバンクホークス"},
+			{name: "楽は東北楽天ゴールデンイーグルスに変換される", abbreviation: "楽", expected: "東北楽天ゴールデンイーグルス"},
+			{name: "西は埼玉西武ライオンズに変換される", abbreviation: "西", expected: "埼玉西武ライオンズ"},
+			{name: "ロは千葉ロッテマリーンズに変換される", abbreviation: "ロ", expected: "千葉ロッテマリーンズ"},
+			{name: "日は北海道日本ハムファイターズに変換される", abbreviation: "日", expected: "北海道日本ハムファイターズ"},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				opponent, err := game.NewOpponent(tt.abbreviation)
+
+				require.NoError(t, err)
+				assert.Equal(t, tt.expected, opponent.Value())
+			})
+		}
+	})
+
+	t.Run("未知の値はそのまま保持する", func(t *testing.T) {
+		opponent, err := game.NewOpponent("未知のチーム")
+
+		require.NoError(t, err)
+		assert.Equal(t, "未知のチーム", opponent.Value())
+	})
+}
+
+func TestOpponent_Equals(t *testing.T) {
+	tests := []struct {
+		name     string
+		a        string
+		b        string
+		expected bool
+	}{
+		{name: "同じ値の対戦相手同士はtrueを返す", a: "阪神タイガース", b: "阪神タイガース", expected: true},
+		{name: "異なる値の対戦相手同士はfalseを返す", a: "阪神タイガース", b: "読売ジャイアンツ", expected: false},
+		{name: "前後の空白差はtrimされて等価になる", a: "阪神タイガース", b: "  阪神タイガース  ", expected: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a, err := game.NewOpponent(tt.a)
+			require.NoError(t, err)
+			b, err := game.NewOpponent(tt.b)
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.expected, a.Equals(b))
+		})
+	}
+}

--- a/backend-go/internal/domain/game/score.go
+++ b/backend-go/internal/domain/game/score.go
@@ -1,0 +1,22 @@
+package game
+
+import "github.com/posiposi/dragons-counter/backend-go/internal/domain"
+
+type Score struct {
+	value int
+}
+
+func NewScore(value int) (Score, error) {
+	if value < 0 {
+		return Score{}, domain.NewError("INVALID_SCORE", "score cannot be negative")
+	}
+	return Score{value: value}, nil
+}
+
+func (s Score) Value() int {
+	return s.value
+}
+
+func (s Score) Equals(other Score) bool {
+	return s.value == other.value
+}

--- a/backend-go/internal/domain/game/score_test.go
+++ b/backend-go/internal/domain/game/score_test.go
@@ -1,0 +1,67 @@
+package game_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/posiposi/dragons-counter/backend-go/internal/domain"
+	"github.com/posiposi/dragons-counter/backend-go/internal/domain/game"
+)
+
+func TestNewScore(t *testing.T) {
+	t.Run("正常な値でスコアを生成できる", func(t *testing.T) {
+		tests := []struct {
+			name  string
+			value int
+		}{
+			{name: "0を保持できる", value: 0},
+			{name: "5を保持できる", value: 5},
+			{name: "15を保持できる", value: 15},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				score, err := game.NewScore(tt.value)
+
+				require.NoError(t, err)
+				assert.Equal(t, tt.value, score.Value())
+			})
+		}
+	})
+
+	t.Run("負数の場合はドメインエラーを返す", func(t *testing.T) {
+		_, err := game.NewScore(-1)
+
+		require.Error(t, err)
+		var domainErr *domain.Error
+		require.True(t, errors.As(err, &domainErr))
+		assert.NotEmpty(t, domainErr.Code)
+	})
+}
+
+func TestScore_Equals(t *testing.T) {
+	tests := []struct {
+		name     string
+		a        int
+		b        int
+		expected bool
+	}{
+		{name: "同じ値のスコア同士はtrueを返す", a: 7, b: 7, expected: true},
+		{name: "異なる値のスコア同士はfalseを返す", a: 3, b: 5, expected: false},
+		{name: "0同士はtrueを返す", a: 0, b: 0, expected: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a, err := game.NewScore(tt.a)
+			require.NoError(t, err)
+			b, err := game.NewScore(tt.b)
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.expected, a.Equals(b))
+		})
+	}
+}

--- a/backend-go/internal/domain/game/stadium.go
+++ b/backend-go/internal/domain/game/stadium.go
@@ -1,0 +1,48 @@
+package game
+
+import (
+	"strings"
+
+	"github.com/posiposi/dragons-counter/backend-go/internal/domain"
+)
+
+type StadiumName struct {
+	value string
+}
+
+func NewStadiumName(value string) (StadiumName, error) {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return StadiumName{}, domain.NewError("INVALID_STADIUM_NAME", "Stadium name cannot be empty")
+	}
+	return StadiumName{value: trimmed}, nil
+}
+
+func (n StadiumName) Value() string {
+	return n.value
+}
+
+func (n StadiumName) Equals(other StadiumName) bool {
+	return n.value == other.value
+}
+
+type Stadium struct {
+	id   StadiumID
+	name StadiumName
+}
+
+func NewStadium(id StadiumID, name StadiumName) Stadium {
+	return Stadium{id: id, name: name}
+}
+
+func (s Stadium) ID() StadiumID {
+	return s.id
+}
+
+func (s Stadium) Name() StadiumName {
+	return s.name
+}
+
+func (s Stadium) Equals(other Stadium) bool {
+	return s.id.Equals(other.id)
+}

--- a/backend-go/internal/domain/game/stadium_test.go
+++ b/backend-go/internal/domain/game/stadium_test.go
@@ -1,0 +1,177 @@
+package game_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/posiposi/dragons-counter/backend-go/internal/domain"
+	"github.com/posiposi/dragons-counter/backend-go/internal/domain/game"
+)
+
+func TestNewStadiumName(t *testing.T) {
+	t.Run("日本語の球場名で生成できる", func(t *testing.T) {
+		name, err := game.NewStadiumName("バンテリンドーム ナゴヤ")
+
+		require.NoError(t, err)
+		assert.Equal(t, "バンテリンドーム ナゴヤ", name.Value())
+	})
+
+	t.Run("英語の球場名で生成できる", func(t *testing.T) {
+		name, err := game.NewStadiumName("Vantelin Dome Nagoya")
+
+		require.NoError(t, err)
+		assert.Equal(t, "Vantelin Dome Nagoya", name.Value())
+	})
+
+	t.Run("空文字または空白のみの場合はドメインエラーを返す", func(t *testing.T) {
+		tests := []struct {
+			name  string
+			value string
+		}{
+			{name: "空文字はエラーになる", value: ""},
+			{name: "空白のみはエラーになる", value: "   "},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				_, err := game.NewStadiumName(tt.value)
+
+				require.Error(t, err)
+				var domainErr *domain.Error
+				require.True(t, errors.As(err, &domainErr))
+				assert.NotEmpty(t, domainErr.Code)
+			})
+		}
+	})
+
+	t.Run("前後の空白を除去して保持する", func(t *testing.T) {
+		name, err := game.NewStadiumName("  甲子園球場  ")
+
+		require.NoError(t, err)
+		assert.Equal(t, "甲子園球場", name.Value())
+	})
+}
+
+func TestStadiumName_Equals(t *testing.T) {
+	tests := []struct {
+		name     string
+		a        string
+		b        string
+		expected bool
+	}{
+		{name: "同じ値の球場名同士はtrueを返す", a: "甲子園球場", b: "甲子園球場", expected: true},
+		{name: "異なる値の球場名同士はfalseを返す", a: "甲子園球場", b: "東京ドーム", expected: false},
+		{name: "前後の空白差はtrimされて等価になる", a: "甲子園球場", b: "  甲子園球場  ", expected: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a, err := game.NewStadiumName(tt.a)
+			require.NoError(t, err)
+			b, err := game.NewStadiumName(tt.b)
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.expected, a.Equals(b))
+		})
+	}
+}
+
+func TestNewStadium(t *testing.T) {
+	t.Run("IDと球場名から生成できる", func(t *testing.T) {
+		id := game.NewStadiumID()
+		name, err := game.NewStadiumName("バンテリンドーム ナゴヤ")
+		require.NoError(t, err)
+
+		stadium := game.NewStadium(id, name)
+
+		assert.True(t, stadium.ID().Equals(id))
+		assert.True(t, stadium.Name().Equals(name))
+	})
+}
+
+func TestStadium_Equals(t *testing.T) {
+	t.Run("同じIDであれば球場名が異なってもtrueを返す", func(t *testing.T) {
+		id, err := game.ParseStadiumID("stadium-001")
+		require.NoError(t, err)
+		nameA, err := game.NewStadiumName("ナゴヤドーム")
+		require.NoError(t, err)
+		nameB, err := game.NewStadiumName("バンテリンドーム ナゴヤ")
+		require.NoError(t, err)
+
+		a := game.NewStadium(id, nameA)
+		b := game.NewStadium(id, nameB)
+
+		assert.True(t, a.Equals(b))
+	})
+
+	t.Run("異なるIDであればfalseを返す", func(t *testing.T) {
+		name, err := game.NewStadiumName("甲子園球場")
+		require.NoError(t, err)
+
+		a := game.NewStadium(game.NewStadiumID(), name)
+		b := game.NewStadium(game.NewStadiumID(), name)
+
+		assert.False(t, a.Equals(b))
+	})
+}
+
+func TestParseStadiumID(t *testing.T) {
+	t.Run("値からStadiumIDを生成できる", func(t *testing.T) {
+		id, err := game.ParseStadiumID("stadium-001")
+
+		require.NoError(t, err)
+		assert.Equal(t, "stadium-001", id.Value())
+	})
+}
+
+func TestStadiumID_Equals(t *testing.T) {
+	t.Run("同じ値のStadiumID同士はtrueを返す", func(t *testing.T) {
+		a, err := game.ParseStadiumID("stadium-001")
+		require.NoError(t, err)
+		b, err := game.ParseStadiumID("stadium-001")
+		require.NoError(t, err)
+
+		assert.True(t, a.Equals(b))
+	})
+
+	t.Run("異なる値のStadiumID同士はfalseを返す", func(t *testing.T) {
+		a, err := game.ParseStadiumID("stadium-001")
+		require.NoError(t, err)
+		b, err := game.ParseStadiumID("stadium-002")
+		require.NoError(t, err)
+
+		assert.False(t, a.Equals(b))
+	})
+}
+
+func TestParseGameID(t *testing.T) {
+	t.Run("値からGameIDを生成できる", func(t *testing.T) {
+		id, err := game.ParseGameID("game-001")
+
+		require.NoError(t, err)
+		assert.Equal(t, "game-001", id.Value())
+	})
+}
+
+func TestGameID_Equals(t *testing.T) {
+	t.Run("同じ値のGameID同士はtrueを返す", func(t *testing.T) {
+		a, err := game.ParseGameID("game-001")
+		require.NoError(t, err)
+		b, err := game.ParseGameID("game-001")
+		require.NoError(t, err)
+
+		assert.True(t, a.Equals(b))
+	})
+
+	t.Run("異なる値のGameID同士はfalseを返す", func(t *testing.T) {
+		a, err := game.ParseGameID("game-001")
+		require.NoError(t, err)
+		b, err := game.ParseGameID("game-002")
+		require.NoError(t, err)
+
+		assert.False(t, a.Equals(b))
+	})
+}


### PR DESCRIPTION
## 概要

Go移行 Phase 1（親Issue #189）の一環として、TypeScript実装のGame集約を `backend-go/internal/domain/game/` パッケージへ移植しました。値オブジェクト・エンティティをTDD（RED→GREEN）で実装し、TSのスペックを1:1で移植しています。

Closes #199

## 変更内容

- `Score`（非負整数）と `GameResult`（スコアからのWIN/LOSE/DRAW自動判定・`IsWin`）を追加
- `GameDate`（未来日禁止・時刻精度・`Format`=YYYY-MM-DD）と `Opponent`（12球団略称→正式名マッピング、未知値はtrimして保持）を追加
- `StadiumName`（trim・空文字拒否）、`Stadium`（ID基準の`Equals`）、`GameID`/`StadiumID`（共有 `domain.ID` 埋め込み）を追加
- `Game` エンティティを追加（コンストラクタでスコアから勝敗を自動判定、`IsVictory`）

## テスト

- 単体テストを追加・実行済み（TSスペックを1:1移植。12球団マッピング全件・境界値・未来日拒否を含む）
- CLAUDE.mdのテスト方針に基づき、Goの型システムで担保される検証（NaN・小数・null等）は除外

🤖 Generated with [Claude Code](https://claude.com/claude-code)