### PR TITLE
UserGameリポジトリ（Query/Command + ソフトデリート + 復活ロジック）を実装

### DIFF
--- a/backend-go/internal/db/query/users_games.sql
+++ b/backend-go/internal/db/query/users_games.sql
@@ -18,3 +18,6 @@ UPDATE users_games SET deleted_at = ?, updated_at = ? WHERE id = ?;
 -- name: RestoreUserGame :exec
 UPDATE users_games SET deleted_at = NULL, impression = ?, updated_at = ?
 WHERE user_id = ? AND game_id = ?;
+
+-- name: GetUserGameByUserIDAndGameIDWithDeleted :one
+SELECT * FROM users_games WHERE user_id = ? AND game_id = ? LIMIT 1;

--- a/backend-go/internal/db/sqlc/querier.go
+++ b/backend-go/internal/db/sqlc/querier.go
@@ -26,6 +26,7 @@ type Querier interface {
 	GetUserByEmail(ctx context.Context, email string) (User, error)
 	GetUserByID(ctx context.Context, id string) (User, error)
 	GetUserGameByUserIDAndGameID(ctx context.Context, arg GetUserGameByUserIDAndGameIDParams) (UsersGame, error)
+	GetUserGameByUserIDAndGameIDWithDeleted(ctx context.Context, arg GetUserGameByUserIDAndGameIDWithDeletedParams) (UsersGame, error)
 	ListStadiums(ctx context.Context) ([]Stadium, error)
 	ListUserGamesByUserID(ctx context.Context, userID string) ([]UsersGame, error)
 	ListUsers(ctx context.Context) ([]User, error)

--- a/backend-go/internal/db/sqlc/users_games.sql.go
+++ b/backend-go/internal/db/sqlc/users_games.sql.go
@@ -63,6 +63,30 @@ func (q *Queries) GetUserGameByUserIDAndGameID(ctx context.Context, arg GetUserG
 	return i, err
 }
 
+const getUserGameByUserIDAndGameIDWithDeleted = `-- name: GetUserGameByUserIDAndGameIDWithDeleted :one
+SELECT id, user_id, game_id, impression, created_at, updated_at, deleted_at FROM users_games WHERE user_id = ? AND game_id = ? LIMIT 1
+`
+
+type GetUserGameByUserIDAndGameIDWithDeletedParams struct {
+	UserID string `json:"user_id"`
+	GameID string `json:"game_id"`
+}
+
+func (q *Queries) GetUserGameByUserIDAndGameIDWithDeleted(ctx context.Context, arg GetUserGameByUserIDAndGameIDWithDeletedParams) (UsersGame, error) {
+	row := q.db.QueryRowContext(ctx, getUserGameByUserIDAndGameIDWithDeleted, arg.UserID, arg.GameID)
+	var i UsersGame
+	err := row.Scan(
+		&i.ID,
+		&i.UserID,
+		&i.GameID,
+		&i.Impression,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.DeletedAt,
+	)
+	return i, err
+}
+
 const listUserGamesByUserID = `-- name: ListUserGamesByUserID :many
 SELECT id, user_id, game_id, impression, created_at, updated_at, deleted_at FROM users_games
 WHERE user_id = ? AND deleted_at IS NULL

--- a/backend-go/internal/domain/repository/user_game_repository.go
+++ b/backend-go/internal/domain/repository/user_game_repository.go
@@ -1,0 +1,17 @@
+package repository
+
+import (
+	"context"
+
+	"github.com/posiposi/dragons-counter/backend-go/internal/domain/model"
+)
+
+type UserGameQueryPort interface {
+	FindByUserID(ctx context.Context, userID model.ID) ([]model.UserGame, error)
+	FindByUserIDAndGameID(ctx context.Context, userID, gameID model.ID) (*model.UserGame, error)
+}
+
+type UserGameCommandPort interface {
+	Save(ctx context.Context, userGame model.UserGame) error
+	SoftDelete(ctx context.Context, userID, gameID model.ID) error
+}

--- a/backend-go/internal/infrastructure/persistence/game_repository_test.go
+++ b/backend-go/internal/infrastructure/persistence/game_repository_test.go
@@ -400,7 +400,7 @@ func TestGameRepository_FindByID(t *testing.T) {
 
 func TestGameRepository_FindByDate(t *testing.T) {
 	db := setupDB(t)
-	repo := gameadapter.NewGameRepository(db)
+	repo := persistence.NewGameRepository(db)
 
 	stadiumID := testPrefix + "stadium-findbydate"
 	stadiumName := "バンテリンドーム ナゴヤ"
@@ -422,7 +422,7 @@ func TestGameRepository_FindByDate(t *testing.T) {
 			cleanupTestGamesAndStadiums(t, db, []string{gameID}, nil)
 		})
 
-		searchDate, err := game.NewGameDate(gameDate)
+		searchDate, err := model.NewGameDate(gameDate)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -447,8 +447,8 @@ func TestGameRepository_FindByDate(t *testing.T) {
 		if got := found.OpponentScore().Value(); got != 3 {
 			t.Errorf("OpponentScore: got %v, want %v", got, 3)
 		}
-		if got := found.Result().Value(); got != game.Win {
-			t.Errorf("Result: got %v, want %v", got, game.Win)
+		if got := found.Result().Value(); got != model.Win {
+			t.Errorf("Result: got %v, want %v", got, model.Win)
 		}
 		if got := found.Stadium().Name().Value(); got != stadiumName {
 			t.Errorf("Stadium.Name: got %v, want %v", got, stadiumName)
@@ -456,7 +456,7 @@ func TestGameRepository_FindByDate(t *testing.T) {
 	})
 
 	t.Run("ゲームが存在しない日付の場合はnilを返す", func(t *testing.T) {
-		searchDate, err := game.NewGameDate(time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC))
+		searchDate, err := model.NewGameDate(time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC))
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -482,7 +482,7 @@ func TestGameRepository_FindByDate(t *testing.T) {
 			cleanupTestGamesAndStadiums(t, db, []string{gameID}, nil)
 		})
 
-		searchDate, err := game.NewGameDate(time.Date(2024, 7, 2, 0, 0, 0, 0, time.UTC))
+		searchDate, err := model.NewGameDate(time.Date(2024, 7, 2, 0, 0, 0, 0, time.UTC))
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}

--- a/backend-go/internal/infrastructure/persistence/user_game_repository.go
+++ b/backend-go/internal/infrastructure/persistence/user_game_repository.go
@@ -1,0 +1,171 @@
+package persistence
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/go-sql-driver/mysql"
+
+	"github.com/posiposi/dragons-counter/backend-go/internal/db/sqlc"
+	"github.com/posiposi/dragons-counter/backend-go/internal/domain/model"
+)
+
+type UserGameRepository struct {
+	queries *sqlc.Queries
+	db      *sql.DB
+}
+
+func NewUserGameRepository(db *sql.DB) *UserGameRepository {
+	return &UserGameRepository{
+		queries: sqlc.New(db),
+		db:      db,
+	}
+}
+
+func (r *UserGameRepository) FindByUserID(ctx context.Context, userID model.ID) ([]model.UserGame, error) {
+	rows, err := r.queries.ListUserGamesByUserID(ctx, userID.Value())
+	if err != nil {
+		return nil, fmt.Errorf("failed to find user games by user id: %w", err)
+	}
+
+	userGames := make([]model.UserGame, 0, len(rows))
+	for _, row := range rows {
+		ug, err := toDomainUserGame(row)
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert user game row: %w", err)
+		}
+		userGames = append(userGames, ug)
+	}
+
+	return userGames, nil
+}
+
+func (r *UserGameRepository) FindByUserIDAndGameID(ctx context.Context, userID, gameID model.ID) (*model.UserGame, error) {
+	row, err := r.queries.GetUserGameByUserIDAndGameID(ctx, sqlc.GetUserGameByUserIDAndGameIDParams{
+		UserID: userID.Value(),
+		GameID: gameID.Value(),
+	})
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to find user game: %w", err)
+	}
+
+	ug, err := toDomainUserGame(row)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert user game row: %w", err)
+	}
+
+	return &ug, nil
+}
+
+func (r *UserGameRepository) Save(ctx context.Context, userGame model.UserGame) error {
+	now := time.Now().Truncate(time.Second)
+
+	existing, err := r.queries.GetUserGameByUserIDAndGameIDWithDeleted(ctx, sqlc.GetUserGameByUserIDAndGameIDWithDeletedParams{
+		UserID: userGame.UserID().Value(),
+		GameID: userGame.GameID().Value(),
+	})
+	if err != nil && err != sql.ErrNoRows {
+		return fmt.Errorf("failed to check existing user game: %w", err)
+	}
+
+	if err != sql.ErrNoRows {
+		if !existing.DeletedAt.Valid && existing.ID != userGame.ID().Value() {
+			return model.NewError("USER_GAME_ALREADY_EXISTS", "この試合は既に観戦登録されています")
+		}
+
+		if existing.DeletedAt.Valid {
+			return r.queries.RestoreUserGame(ctx, sqlc.RestoreUserGameParams{
+				Impression: toSQLNullString(userGame.Impression()),
+				UpdatedAt:  now,
+				UserID:     userGame.UserID().Value(),
+				GameID:     userGame.GameID().Value(),
+			})
+		}
+
+		if existing.ID == userGame.ID().Value() {
+			return r.queries.RestoreUserGame(ctx, sqlc.RestoreUserGameParams{
+				Impression: toSQLNullString(userGame.Impression()),
+				UpdatedAt:  now,
+				UserID:     userGame.UserID().Value(),
+				GameID:     userGame.GameID().Value(),
+			})
+		}
+	}
+
+	err = r.queries.CreateUserGame(ctx, sqlc.CreateUserGameParams{
+		ID:         userGame.ID().Value(),
+		UserID:     userGame.UserID().Value(),
+		GameID:     userGame.GameID().Value(),
+		Impression: toSQLNullString(userGame.Impression()),
+		CreatedAt:  now,
+		UpdatedAt:  now,
+	})
+	if err != nil {
+		var mysqlErr *mysql.MySQLError
+		if errors.As(err, &mysqlErr) && mysqlErr.Number == 1062 {
+			return model.NewError("USER_GAME_ALREADY_EXISTS", "この試合は既に観戦登録されています")
+		}
+		return fmt.Errorf("failed to save user game: %w", err)
+	}
+
+	return nil
+}
+
+func (r *UserGameRepository) SoftDelete(ctx context.Context, userID, gameID model.ID) error {
+	found, err := r.FindByUserIDAndGameID(ctx, userID, gameID)
+	if err != nil {
+		return err
+	}
+	if found == nil {
+		return nil
+	}
+
+	now := time.Now().Truncate(time.Second)
+	return r.queries.SoftDeleteUserGame(ctx, sqlc.SoftDeleteUserGameParams{
+		DeletedAt: sql.NullTime{Time: now, Valid: true},
+		UpdatedAt: now,
+		ID:        found.ID().Value(),
+	})
+}
+
+func toDomainUserGame(row sqlc.UsersGame) (model.UserGame, error) {
+	ugID, err := model.ParseUserGameID(row.ID)
+	if err != nil {
+		return model.UserGame{}, fmt.Errorf("failed to parse user game id: %w", err)
+	}
+
+	uid, err := model.ParseID(row.UserID)
+	if err != nil {
+		return model.UserGame{}, fmt.Errorf("failed to parse user id: %w", err)
+	}
+
+	gid, err := model.ParseID(row.GameID)
+	if err != nil {
+		return model.UserGame{}, fmt.Errorf("failed to parse game id: %w", err)
+	}
+
+	var impressionPtr *string
+	if row.Impression.Valid {
+		impressionPtr = &row.Impression.String
+	}
+	impression, err := model.NewImpression(impressionPtr)
+	if err != nil {
+		return model.UserGame{}, fmt.Errorf("failed to create impression: %w", err)
+	}
+
+	return model.UserGameFromRepository(ugID, uid, gid, impression, row.CreatedAt, row.UpdatedAt), nil
+}
+
+func toSQLNullString(imp model.Impression) sql.NullString {
+	v := imp.Value()
+	if v == nil {
+		return sql.NullString{}
+	}
+	return sql.NullString{String: *v, Valid: true}
+}

--- a/backend-go/internal/infrastructure/persistence/user_game_repository_test.go
+++ b/backend-go/internal/infrastructure/persistence/user_game_repository_test.go
@@ -1,0 +1,457 @@
+//go:build integration
+
+package persistence_test
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/posiposi/dragons-counter/backend-go/internal/db/sqlc"
+	"github.com/posiposi/dragons-counter/backend-go/internal/domain/model"
+	"github.com/posiposi/dragons-counter/backend-go/internal/infrastructure/persistence"
+)
+
+const ugTestPrefix = "ug-repo-test-"
+
+func insertTestUser(t *testing.T, db *sql.DB, id, email string) {
+	t.Helper()
+	now := time.Now().Truncate(time.Second)
+	queries := sqlc.New(db)
+	err := queries.CreateUser(context.Background(), sqlc.CreateUserParams{
+		ID:        id,
+		Email:     email,
+		Password:  "hashed-password",
+		Role:      sqlc.UsersRoleUser,
+		CreatedAt: now,
+		UpdatedAt: now,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error inserting test user: %v", err)
+	}
+}
+
+func insertTestGame(t *testing.T, db *sql.DB, id, stadiumID string) {
+	t.Helper()
+	now := time.Now().Truncate(time.Second)
+	queries := sqlc.New(db)
+	err := queries.CreateGame(context.Background(), sqlc.CreateGameParams{
+		ID:            id,
+		GameDate:      time.Date(2025, 6, 15, 18, 0, 0, 0, time.UTC),
+		Opponent:      "阪神タイガース",
+		DragonsScore:  5,
+		OpponentScore: 3,
+		Result:        sqlc.GamesResultWin,
+		StadiumID:     stadiumID,
+		CreatedAt:     now,
+		UpdatedAt:     now,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error inserting test game: %v", err)
+	}
+}
+
+func cleanupUserGameTestData(t *testing.T, db *sql.DB, userGameIDs, gameIDs, userIDs, stadiumIDs []string) {
+	t.Helper()
+	ctx := context.Background()
+	for _, id := range userGameIDs {
+		_, err := db.ExecContext(ctx, "DELETE FROM users_games WHERE id = ?", id)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	}
+	for _, id := range gameIDs {
+		_, err := db.ExecContext(ctx, "DELETE FROM games WHERE id = ?", id)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	}
+	for _, id := range userIDs {
+		_, err := db.ExecContext(ctx, "DELETE FROM users WHERE id = ?", id)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	}
+	for _, id := range stadiumIDs {
+		_, err := db.ExecContext(ctx, "DELETE FROM stadiums WHERE id = ?", id)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	}
+}
+
+func newTestUserGame(t *testing.T, userID, gameID string, impression *string) model.UserGame {
+	t.Helper()
+	uid, err := model.ParseID(userID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	gid, err := model.ParseID(gameID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	imp, err := model.NewImpression(impression)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	return model.CreateNewUserGame(uid, gid, imp)
+}
+
+func setupUserGameTestFixtures(t *testing.T, db *sql.DB, suffix string) (stadiumID, userID, gameID string) {
+	t.Helper()
+	stadiumID = ugTestPrefix + "stadium-" + suffix
+	userID = ugTestPrefix + "user-" + suffix
+	gameID = ugTestPrefix + "game-" + suffix
+
+	insertTestStadium(t, db, stadiumID, "バンテリンドーム ナゴヤ")
+	insertTestUser(t, db, userID, ugTestPrefix+suffix+"@example.com")
+	insertTestGame(t, db, gameID, stadiumID)
+	return
+}
+
+func TestUserGameRepository_Save(t *testing.T) {
+	db := setupDB(t)
+	repo := persistence.NewUserGameRepository(db)
+
+	stadiumID, userID, gameID := setupUserGameTestFixtures(t, db, "save")
+	t.Cleanup(func() {
+		cleanupUserGameTestData(t, db, nil, []string{gameID}, []string{userID}, []string{stadiumID})
+	})
+
+	t.Run("新規のUserGameを保存しFindByUserIDAndGameIDで全フィールドを検証できる", func(t *testing.T) {
+		impression := "素晴らしい試合だった"
+		ug := newTestUserGame(t, userID, gameID, &impression)
+
+		t.Cleanup(func() {
+			cleanupUserGameTestData(t, db, []string{ug.ID().Value()}, nil, nil, nil)
+		})
+
+		err := repo.Save(context.Background(), ug)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		uid, _ := model.ParseID(userID)
+		gid, _ := model.ParseID(gameID)
+		found, err := repo.FindByUserIDAndGameID(context.Background(), uid, gid)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if found == nil {
+			t.Fatal("got nil, want non-nil")
+		}
+
+		if got := found.UserID().Value(); got != userID {
+			t.Errorf("UserID: got %v, want %v", got, userID)
+		}
+		if got := found.GameID().Value(); got != gameID {
+			t.Errorf("GameID: got %v, want %v", got, gameID)
+		}
+		if found.Impression().IsEmpty() {
+			t.Error("Impression: got empty, want non-empty")
+		}
+		if got := found.Impression().Value(); got == nil || *got != impression {
+			t.Errorf("Impression: got %v, want %v", got, impression)
+		}
+	})
+
+	t.Run("感想なしのUserGameを保存できる", func(t *testing.T) {
+		gameID2 := ugTestPrefix + "game-save-noimp"
+		insertTestGame(t, db, gameID2, stadiumID)
+		ug := newTestUserGame(t, userID, gameID2, nil)
+
+		t.Cleanup(func() {
+			cleanupUserGameTestData(t, db, []string{ug.ID().Value()}, []string{gameID2}, nil, nil)
+		})
+
+		err := repo.Save(context.Background(), ug)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		uid, _ := model.ParseID(userID)
+		gid, _ := model.ParseID(gameID2)
+		found, err := repo.FindByUserIDAndGameID(context.Background(), uid, gid)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if found == nil {
+			t.Fatal("got nil, want non-nil")
+		}
+		if !found.Impression().IsEmpty() {
+			t.Errorf("Impression: got non-empty, want empty")
+		}
+	})
+
+	t.Run("同一user_id/game_idで異なるIDのUserGameを保存すると重複エラーになる", func(t *testing.T) {
+		gameID3 := ugTestPrefix + "game-save-dup"
+		insertTestGame(t, db, gameID3, stadiumID)
+
+		impression := "一回目"
+		ug1 := newTestUserGame(t, userID, gameID3, &impression)
+
+		t.Cleanup(func() {
+			cleanupUserGameTestData(t, db, []string{ug1.ID().Value()}, []string{gameID3}, nil, nil)
+		})
+
+		err := repo.Save(context.Background(), ug1)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		impression2 := "二回目"
+		ug2 := newTestUserGame(t, userID, gameID3, &impression2)
+
+		err = repo.Save(context.Background(), ug2)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+
+		var domainErr *model.Error
+		if !errors.As(err, &domainErr) {
+			t.Fatalf("expected *model.Error, got %T: %v", err, err)
+		}
+		if domainErr.Code != "USER_GAME_ALREADY_EXISTS" {
+			t.Errorf("Code: got %v, want USER_GAME_ALREADY_EXISTS", domainErr.Code)
+		}
+	})
+
+	t.Run("同一IDのUserGameを再保存するとimpressionが更新される", func(t *testing.T) {
+		gameID4 := ugTestPrefix + "game-save-update"
+		insertTestGame(t, db, gameID4, stadiumID)
+
+		impression := "初回感想"
+		ug := newTestUserGame(t, userID, gameID4, &impression)
+
+		t.Cleanup(func() {
+			cleanupUserGameTestData(t, db, []string{ug.ID().Value()}, []string{gameID4}, nil, nil)
+		})
+
+		err := repo.Save(context.Background(), ug)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		newImpression := "更新後の感想"
+		imp, _ := model.NewImpression(&newImpression)
+		updated := ug.UpdateImpression(imp)
+
+		err = repo.Save(context.Background(), updated)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		uid, _ := model.ParseID(userID)
+		gid, _ := model.ParseID(gameID4)
+		found, err := repo.FindByUserIDAndGameID(context.Background(), uid, gid)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if found == nil {
+			t.Fatal("got nil, want non-nil")
+		}
+		if got := found.Impression().Value(); got == nil || *got != newImpression {
+			t.Errorf("Impression: got %v, want %v", got, newImpression)
+		}
+	})
+}
+
+func TestUserGameRepository_FindByUserID(t *testing.T) {
+	db := setupDB(t)
+	repo := persistence.NewUserGameRepository(db)
+
+	stadiumID, userID, gameID := setupUserGameTestFixtures(t, db, "findbyuid")
+	gameID2 := ugTestPrefix + "game-findbyuid-2"
+	insertTestGame(t, db, gameID2, stadiumID)
+
+	impression1 := "感想1"
+	impression2 := "感想2"
+	ug1 := newTestUserGame(t, userID, gameID, &impression1)
+	ug2 := newTestUserGame(t, userID, gameID2, &impression2)
+
+	if err := repo.Save(context.Background(), ug1); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if err := repo.Save(context.Background(), ug2); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	t.Cleanup(func() {
+		cleanupUserGameTestData(t, db,
+			[]string{ug1.ID().Value(), ug2.ID().Value()},
+			[]string{gameID, gameID2},
+			[]string{userID},
+			[]string{stadiumID},
+		)
+	})
+
+	t.Run("同一ユーザーの2件が返却される", func(t *testing.T) {
+		uid, _ := model.ParseID(userID)
+		results, err := repo.FindByUserID(context.Background(), uid)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(results) != 2 {
+			t.Fatalf("got len %d, want 2", len(results))
+		}
+	})
+
+	t.Run("存在しないユーザーIDでは空配列が返る", func(t *testing.T) {
+		uid, _ := model.ParseID(ugTestPrefix + "nonexistent-user")
+		results, err := repo.FindByUserID(context.Background(), uid)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(results) != 0 {
+			t.Errorf("got len %d, want 0", len(results))
+		}
+	})
+}
+
+func TestUserGameRepository_FindByUserIDAndGameID(t *testing.T) {
+	db := setupDB(t)
+	repo := persistence.NewUserGameRepository(db)
+
+	stadiumID, userID, gameID := setupUserGameTestFixtures(t, db, "findbyuidgid")
+
+	impression := "テスト感想"
+	ug := newTestUserGame(t, userID, gameID, &impression)
+	if err := repo.Save(context.Background(), ug); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	t.Cleanup(func() {
+		cleanupUserGameTestData(t, db,
+			[]string{ug.ID().Value()},
+			[]string{gameID},
+			[]string{userID},
+			[]string{stadiumID},
+		)
+	})
+
+	t.Run("保存済みのUserGameを全フィールド検証できる", func(t *testing.T) {
+		uid, _ := model.ParseID(userID)
+		gid, _ := model.ParseID(gameID)
+		found, err := repo.FindByUserIDAndGameID(context.Background(), uid, gid)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if found == nil {
+			t.Fatal("got nil, want non-nil")
+		}
+		if got := found.UserID().Value(); got != userID {
+			t.Errorf("UserID: got %v, want %v", got, userID)
+		}
+		if got := found.GameID().Value(); got != gameID {
+			t.Errorf("GameID: got %v, want %v", got, gameID)
+		}
+		if got := found.Impression().Value(); got == nil || *got != impression {
+			t.Errorf("Impression: got %v, want %v", got, impression)
+		}
+	})
+
+	t.Run("存在しない組み合わせではnilが返る", func(t *testing.T) {
+		uid, _ := model.ParseID(ugTestPrefix + "nonexistent-user")
+		gid, _ := model.ParseID(ugTestPrefix + "nonexistent-game")
+		found, err := repo.FindByUserIDAndGameID(context.Background(), uid, gid)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if found != nil {
+			t.Errorf("got %v, want nil", found)
+		}
+	})
+}
+
+func TestUserGameRepository_SoftDelete(t *testing.T) {
+	db := setupDB(t)
+	repo := persistence.NewUserGameRepository(db)
+
+	stadiumID, userID, gameID := setupUserGameTestFixtures(t, db, "softdel")
+
+	t.Cleanup(func() {
+		cleanupUserGameTestData(t, db, nil, []string{gameID}, []string{userID}, []string{stadiumID})
+	})
+
+	t.Run("保存後にSoftDeleteするとFindByUserIDAndGameIDでnilになる", func(t *testing.T) {
+		impression := "削除対象"
+		ug := newTestUserGame(t, userID, gameID, &impression)
+
+		t.Cleanup(func() {
+			cleanupUserGameTestData(t, db, []string{ug.ID().Value()}, nil, nil, nil)
+		})
+
+		err := repo.Save(context.Background(), ug)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		uid, _ := model.ParseID(userID)
+		gid, _ := model.ParseID(gameID)
+		err = repo.SoftDelete(context.Background(), uid, gid)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		found, err := repo.FindByUserIDAndGameID(context.Background(), uid, gid)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if found != nil {
+			t.Errorf("got %v, want nil", found)
+		}
+	})
+
+	t.Run("存在しないUserGameのSoftDeleteでもエラーにならない", func(t *testing.T) {
+		uid, _ := model.ParseID(ugTestPrefix + "nonexistent-user")
+		gid, _ := model.ParseID(ugTestPrefix + "nonexistent-game")
+		err := repo.SoftDelete(context.Background(), uid, gid)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("SoftDelete後に同一user/gameで再登録すると復活する", func(t *testing.T) {
+		gameID2 := ugTestPrefix + "game-softdel-restore"
+		insertTestGame(t, db, gameID2, stadiumID)
+
+		impression := "削除前の感想"
+		ug := newTestUserGame(t, userID, gameID2, &impression)
+
+		t.Cleanup(func() {
+			cleanupUserGameTestData(t, db, []string{ug.ID().Value()}, []string{gameID2}, nil, nil)
+		})
+
+		err := repo.Save(context.Background(), ug)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		uid, _ := model.ParseID(userID)
+		gid, _ := model.ParseID(gameID2)
+		err = repo.SoftDelete(context.Background(), uid, gid)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		newImpression := "復活後の感想"
+		ug2 := newTestUserGame(t, userID, gameID2, &newImpression)
+		err = repo.Save(context.Background(), ug2)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		found, err := repo.FindByUserIDAndGameID(context.Background(), uid, gid)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if found == nil {
+			t.Fatal("got nil, want non-nil")
+		}
+		if got := found.Impression().Value(); got == nil || *got != newImpression {
+			t.Errorf("Impression: got %v, want %v", got, newImpression)
+		}
+	})
+}


### PR DESCRIPTION
## 概要

Go移行 Phase 2（親Issue #190）の一環として、UserGame集約のリポジトリ層を実装しました。ソフトデリート（`deleted_at`）対応と、削除済みレコードの復活ロジックを含みます。

Closes #206

## 変更内容

- `UserGameQueryPort`（FindByUserID / FindByUserIDAndGameID）と `UserGameCommandPort`（Save / SoftDelete）インターフェースを `domain/repository/` に定義
- `UserGameRepository` アダプタを `infrastructure/persistence/` に実装
  - Save: 削除済みレコードの復活（`GetUserGameByUserIDAndGameIDWithDeleted` で削除済み含む検索 → `RestoreUserGame` で `deleted_at=NULL` に復元）、`ER_DUP_ENTRY(1062)` を `USER_GAME_ALREADY_EXISTS` ドメインエラーに変換
  - SoftDelete: `deleted_at` に現在時刻をセット。存在しない場合もエラーにしない
  - 全read系クエリに `deleted_at IS NULL` フィルタ
- sqlcクエリに `GetUserGameByUserIDAndGameIDWithDeleted`（削除済み含む検索）を追加

## テスト

- integrationテスト（`//go:build integration`、test-db接続）で11ケースを検証（新規保存、感想なし保存、重複エラー、更新、FindByUserID/FindByUserIDAndGameID、SoftDelete後の非表示、存在しないSoftDelete、SoftDelete後の再登録復活）

🤖 Generated with [Claude Code](https://claude.com/claude-code)