### PR TITLE
Userリポジトリ（Query/Command + 承認履歴 + email重複エラー変換）を実装

### DIFF
--- a/backend-go/internal/domain/repository/user_repository.go
+++ b/backend-go/internal/domain/repository/user_repository.go
@@ -1,0 +1,18 @@
+package repository
+
+import (
+	"context"
+
+	"github.com/posiposi/dragons-counter/backend-go/internal/domain/model"
+)
+
+type UserQueryPort interface {
+	FindByEmail(ctx context.Context, email model.Email) (*model.User, error)
+	FindByID(ctx context.Context, id model.UserID) (*model.User, error)
+	FindAll(ctx context.Context) ([]model.User, error)
+}
+
+type UserCommandPort interface {
+	Save(ctx context.Context, user model.User) error
+	UpdateRegistrationStatus(ctx context.Context, user model.User) error
+}

--- a/backend-go/internal/infrastructure/persistence/game_repository_test.go
+++ b/backend-go/internal/infrastructure/persistence/game_repository_test.go
@@ -400,7 +400,7 @@ func TestGameRepository_FindByID(t *testing.T) {
 
 func TestGameRepository_FindByDate(t *testing.T) {
 	db := setupDB(t)
-	repo := gameadapter.NewGameRepository(db)
+	repo := persistence.NewGameRepository(db)
 
 	stadiumID := testPrefix + "stadium-findbydate"
 	stadiumName := "バンテリンドーム ナゴヤ"
@@ -422,7 +422,7 @@ func TestGameRepository_FindByDate(t *testing.T) {
 			cleanupTestGamesAndStadiums(t, db, []string{gameID}, nil)
 		})
 
-		searchDate, err := game.NewGameDate(gameDate)
+		searchDate, err := model.NewGameDate(gameDate)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -447,8 +447,8 @@ func TestGameRepository_FindByDate(t *testing.T) {
 		if got := found.OpponentScore().Value(); got != 3 {
 			t.Errorf("OpponentScore: got %v, want %v", got, 3)
 		}
-		if got := found.Result().Value(); got != game.Win {
-			t.Errorf("Result: got %v, want %v", got, game.Win)
+		if got := found.Result().Value(); got != model.Win {
+			t.Errorf("Result: got %v, want %v", got, model.Win)
 		}
 		if got := found.Stadium().Name().Value(); got != stadiumName {
 			t.Errorf("Stadium.Name: got %v, want %v", got, stadiumName)
@@ -456,7 +456,7 @@ func TestGameRepository_FindByDate(t *testing.T) {
 	})
 
 	t.Run("ゲームが存在しない日付の場合はnilを返す", func(t *testing.T) {
-		searchDate, err := game.NewGameDate(time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC))
+		searchDate, err := model.NewGameDate(time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC))
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -482,7 +482,7 @@ func TestGameRepository_FindByDate(t *testing.T) {
 			cleanupTestGamesAndStadiums(t, db, []string{gameID}, nil)
 		})
 
-		searchDate, err := game.NewGameDate(time.Date(2024, 7, 2, 0, 0, 0, 0, time.UTC))
+		searchDate, err := model.NewGameDate(time.Date(2024, 7, 2, 0, 0, 0, 0, time.UTC))
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}

--- a/backend-go/internal/infrastructure/persistence/user_repository.go
+++ b/backend-go/internal/infrastructure/persistence/user_repository.go
@@ -1,0 +1,204 @@
+package persistence
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/go-sql-driver/mysql"
+	"github.com/posiposi/dragons-counter/backend-go/internal/db"
+	"github.com/posiposi/dragons-counter/backend-go/internal/db/sqlc"
+	"github.com/posiposi/dragons-counter/backend-go/internal/domain/model"
+)
+
+type UserRepository struct {
+	queries *sqlc.Queries
+	db      *sql.DB
+}
+
+func NewUserRepository(database *sql.DB) *UserRepository {
+	return &UserRepository{
+		queries: sqlc.New(database),
+		db:      database,
+	}
+}
+
+func (r *UserRepository) FindByEmail(ctx context.Context, email model.Email) (*model.User, error) {
+	row, err := r.queries.GetUserByEmail(ctx, email.Value())
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to find user by email: %w", err)
+	}
+
+	regRow, err := r.queries.GetLatestRegistrationByUserID(ctx, row.ID)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, fmt.Errorf("registration request not found for user %s", row.ID)
+		}
+		return nil, fmt.Errorf("failed to get registration status: %w", err)
+	}
+
+	u, err := toDomainUser(userRow{
+		ID:                 row.ID,
+		Email:              row.Email,
+		Password:           row.Password,
+		Role:               row.Role,
+		RegistrationStatus: regRow.Status,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert user row: %w", err)
+	}
+
+	return &u, nil
+}
+
+func (r *UserRepository) FindByID(ctx context.Context, id model.UserID) (*model.User, error) {
+	row, err := r.queries.GetUserByID(ctx, id.Value())
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to find user by id: %w", err)
+	}
+
+	regRow, err := r.queries.GetLatestRegistrationByUserID(ctx, row.ID)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, fmt.Errorf("registration request not found for user %s", row.ID)
+		}
+		return nil, fmt.Errorf("failed to get registration status: %w", err)
+	}
+
+	u, err := toDomainUser(userRow{
+		ID:                 row.ID,
+		Email:              row.Email,
+		Password:           row.Password,
+		Role:               row.Role,
+		RegistrationStatus: regRow.Status,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert user row: %w", err)
+	}
+
+	return &u, nil
+}
+
+func (r *UserRepository) FindAll(ctx context.Context) ([]model.User, error) {
+	rows, err := r.queries.ListUsers(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list users: %w", err)
+	}
+
+	users := make([]model.User, 0, len(rows))
+	for _, row := range rows {
+		regRow, err := r.queries.GetLatestRegistrationByUserID(ctx, row.ID)
+		if err != nil {
+			if err == sql.ErrNoRows {
+				continue
+			}
+			return nil, fmt.Errorf("failed to get registration status for user %s: %w", row.ID, err)
+		}
+
+		u, err := toDomainUser(userRow{
+			ID:                 row.ID,
+			Email:              row.Email,
+			Password:           row.Password,
+			Role:               row.Role,
+			RegistrationStatus: regRow.Status,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert user row: %w", err)
+		}
+		users = append(users, u)
+	}
+
+	return users, nil
+}
+
+func (r *UserRepository) Save(ctx context.Context, user model.User) error {
+	return db.WithTx(ctx, r.db, func(tx *sql.Tx) error {
+		qtx := sqlc.New(tx)
+		now := time.Now()
+
+		err := qtx.CreateUser(ctx, sqlc.CreateUserParams{
+			ID:        user.ID().Value(),
+			Email:     user.Email().Value(),
+			Password:  user.Password().Hash(),
+			Role:      sqlc.UsersRole(strings.ToLower(string(user.Role()))),
+			CreatedAt: now,
+			UpdatedAt: now,
+		})
+		if err != nil {
+			var mysqlErr *mysql.MySQLError
+			if errors.As(err, &mysqlErr) && mysqlErr.Number == 1062 {
+				return model.NewError("USER_ALREADY_EXISTS", "user with this email already exists")
+			}
+			return fmt.Errorf("failed to create user: %w", err)
+		}
+
+		err = qtx.CreateRegistrationRequest(ctx, sqlc.CreateRegistrationRequestParams{
+			ID:                 model.NewID().Value(),
+			UserID:             user.ID().Value(),
+			Status:             sqlc.UserRegistrationRequestsStatus(strings.ToLower(string(user.RegistrationStatus()))),
+			Reasonforrejection: sql.NullString{},
+			CreatedAt:          now,
+			UpdatedAt:          now,
+		})
+		if err != nil {
+			return fmt.Errorf("failed to create registration request: %w", err)
+		}
+
+		return nil
+	})
+}
+
+func (r *UserRepository) UpdateRegistrationStatus(ctx context.Context, user model.User) error {
+	now := time.Now()
+	err := r.queries.CreateRegistrationRequest(ctx, sqlc.CreateRegistrationRequestParams{
+		ID:                 model.NewID().Value(),
+		UserID:             user.ID().Value(),
+		Status:             sqlc.UserRegistrationRequestsStatus(strings.ToLower(string(user.RegistrationStatus()))),
+		Reasonforrejection: sql.NullString{},
+		CreatedAt:          now,
+		UpdatedAt:          now,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to update registration status: %w", err)
+	}
+	return nil
+}
+
+type userRow struct {
+	ID                 string
+	Email              string
+	Password           string
+	Role               sqlc.UsersRole
+	RegistrationStatus sqlc.UserRegistrationRequestsStatus
+}
+
+func toDomainUser(row userRow) (model.User, error) {
+	uid, err := model.ParseUserID(row.ID)
+	if err != nil {
+		return model.User{}, fmt.Errorf("failed to parse user id: %w", err)
+	}
+
+	email, err := model.NewEmail(row.Email)
+	if err != nil {
+		return model.User{}, fmt.Errorf("failed to create email: %w", err)
+	}
+
+	pw, err := model.NewPasswordFromHash(row.Password)
+	if err != nil {
+		return model.User{}, fmt.Errorf("failed to create password: %w", err)
+	}
+
+	role := model.UserRole(strings.ToUpper(string(row.Role)))
+	status := model.RegistrationStatus(strings.ToUpper(string(row.RegistrationStatus)))
+
+	return model.UserFromRepository(uid, email, pw, status, role), nil
+}

--- a/backend-go/internal/infrastructure/persistence/user_repository_test.go
+++ b/backend-go/internal/infrastructure/persistence/user_repository_test.go
@@ -1,0 +1,325 @@
+//go:build integration
+
+package persistence_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	_ "github.com/go-sql-driver/mysql"
+
+	"github.com/posiposi/dragons-counter/backend-go/internal/domain/model"
+	"github.com/posiposi/dragons-counter/backend-go/internal/infrastructure/persistence"
+)
+
+const userTestPrefix = "user-repo-test-"
+
+func newTestUser(t *testing.T, emailAddr string) model.User {
+	t.Helper()
+	email, err := model.NewEmail(emailAddr)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	pw, err := model.NewPasswordFromPlainText("Test1234!")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	return model.CreateNewUser(email, pw)
+}
+
+func TestUserRepository_Save(t *testing.T) {
+	db := setupDB(t)
+	repo := persistence.NewUserRepository(db)
+
+	user := newTestUser(t, userTestPrefix+"save@example.com")
+	t.Cleanup(func() {
+		ctx := context.Background()
+		db.ExecContext(ctx, "DELETE FROM user_registration_requests WHERE user_id = ?", user.ID().Value())
+		db.ExecContext(ctx, "DELETE FROM users WHERE id = ?", user.ID().Value())
+	})
+
+	err := repo.Save(context.Background(), user)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	found, err := repo.FindByEmail(context.Background(), user.Email())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if found == nil {
+		t.Fatal("got nil, want non-nil")
+	}
+	if got := found.Email().Value(); got != user.Email().Value() {
+		t.Errorf("Email: got %v, want %v", got, user.Email().Value())
+	}
+	if got := found.Role(); got != model.RoleUser {
+		t.Errorf("Role: got %v, want %v", got, model.RoleUser)
+	}
+	if got := found.RegistrationStatus(); got != model.RegistrationStatusPending {
+		t.Errorf("RegistrationStatus: got %v, want %v", got, model.RegistrationStatusPending)
+	}
+}
+
+func TestUserRepository_Save_DuplicateEmail(t *testing.T) {
+	db := setupDB(t)
+	repo := persistence.NewUserRepository(db)
+
+	user1 := newTestUser(t, userTestPrefix+"dup@example.com")
+	t.Cleanup(func() {
+		ctx := context.Background()
+		db.ExecContext(ctx, "DELETE FROM user_registration_requests WHERE user_id = ?", user1.ID().Value())
+		db.ExecContext(ctx, "DELETE FROM users WHERE id = ?", user1.ID().Value())
+	})
+
+	err := repo.Save(context.Background(), user1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	email, _ := model.NewEmail(userTestPrefix + "dup@example.com")
+	pw, _ := model.NewPasswordFromPlainText("Test1234!")
+	user2 := model.CreateNewUser(email, pw)
+	t.Cleanup(func() {
+		ctx := context.Background()
+		db.ExecContext(ctx, "DELETE FROM user_registration_requests WHERE user_id = ?", user2.ID().Value())
+		db.ExecContext(ctx, "DELETE FROM users WHERE id = ?", user2.ID().Value())
+	})
+
+	err = repo.Save(context.Background(), user2)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	var modelErr *model.Error
+	if !errors.As(err, &modelErr) {
+		t.Fatalf("expected *model.Error, got %T: %v", err, err)
+	}
+	if modelErr.Code != "USER_ALREADY_EXISTS" {
+		t.Errorf("Code: got %v, want USER_ALREADY_EXISTS", modelErr.Code)
+	}
+}
+
+func TestUserRepository_FindByEmail_Exists(t *testing.T) {
+	db := setupDB(t)
+	repo := persistence.NewUserRepository(db)
+
+	user := newTestUser(t, userTestPrefix+"findbyemail@example.com")
+	t.Cleanup(func() {
+		ctx := context.Background()
+		db.ExecContext(ctx, "DELETE FROM user_registration_requests WHERE user_id = ?", user.ID().Value())
+		db.ExecContext(ctx, "DELETE FROM users WHERE id = ?", user.ID().Value())
+	})
+
+	if err := repo.Save(context.Background(), user); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	found, err := repo.FindByEmail(context.Background(), user.Email())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if found == nil {
+		t.Fatal("got nil, want non-nil")
+	}
+	if got := found.ID().Value(); got != user.ID().Value() {
+		t.Errorf("ID: got %v, want %v", got, user.ID().Value())
+	}
+	if got := found.Email().Value(); got != user.Email().Value() {
+		t.Errorf("Email: got %v, want %v", got, user.Email().Value())
+	}
+	if got := found.Role(); got != model.RoleUser {
+		t.Errorf("Role: got %v, want %v", got, model.RoleUser)
+	}
+	if got := found.RegistrationStatus(); got != model.RegistrationStatusPending {
+		t.Errorf("RegistrationStatus: got %v, want %v", got, model.RegistrationStatusPending)
+	}
+}
+
+func TestUserRepository_FindByEmail_NotFound(t *testing.T) {
+	db := setupDB(t)
+	repo := persistence.NewUserRepository(db)
+
+	email, _ := model.NewEmail(userTestPrefix + "nonexistent@example.com")
+	found, err := repo.FindByEmail(context.Background(), email)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if found != nil {
+		t.Errorf("got %v, want nil", found)
+	}
+}
+
+func TestUserRepository_FindByID_Exists(t *testing.T) {
+	db := setupDB(t)
+	repo := persistence.NewUserRepository(db)
+
+	user := newTestUser(t, userTestPrefix+"findbyid@example.com")
+	t.Cleanup(func() {
+		ctx := context.Background()
+		db.ExecContext(ctx, "DELETE FROM user_registration_requests WHERE user_id = ?", user.ID().Value())
+		db.ExecContext(ctx, "DELETE FROM users WHERE id = ?", user.ID().Value())
+	})
+
+	if err := repo.Save(context.Background(), user); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	found, err := repo.FindByID(context.Background(), user.ID())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if found == nil {
+		t.Fatal("got nil, want non-nil")
+	}
+	if got := found.ID().Value(); got != user.ID().Value() {
+		t.Errorf("ID: got %v, want %v", got, user.ID().Value())
+	}
+	if got := found.Email().Value(); got != user.Email().Value() {
+		t.Errorf("Email: got %v, want %v", got, user.Email().Value())
+	}
+	if got := found.Role(); got != model.RoleUser {
+		t.Errorf("Role: got %v, want %v", got, model.RoleUser)
+	}
+	if got := found.RegistrationStatus(); got != model.RegistrationStatusPending {
+		t.Errorf("RegistrationStatus: got %v, want %v", got, model.RegistrationStatusPending)
+	}
+}
+
+func TestUserRepository_FindByID_NotFound(t *testing.T) {
+	db := setupDB(t)
+	repo := persistence.NewUserRepository(db)
+
+	id, _ := model.ParseUserID("00000000-0000-0000-0000-000000000000")
+	found, err := repo.FindByID(context.Background(), id)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if found != nil {
+		t.Errorf("got %v, want nil", found)
+	}
+}
+
+func TestUserRepository_FindAll(t *testing.T) {
+	db := setupDB(t)
+	repo := persistence.NewUserRepository(db)
+
+	user1 := newTestUser(t, userTestPrefix+"findall1@example.com")
+	user2 := newTestUser(t, userTestPrefix+"findall2@example.com")
+	t.Cleanup(func() {
+		ctx := context.Background()
+		for _, u := range []model.User{user1, user2} {
+			db.ExecContext(ctx, "DELETE FROM user_registration_requests WHERE user_id = ?", u.ID().Value())
+			db.ExecContext(ctx, "DELETE FROM users WHERE id = ?", u.ID().Value())
+		}
+	})
+
+	if err := repo.Save(context.Background(), user1); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if err := repo.Save(context.Background(), user2); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	users, err := repo.FindAll(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	foundEmails := make(map[string]bool)
+	for _, u := range users {
+		if strings.HasPrefix(u.Email().Value(), userTestPrefix) {
+			foundEmails[u.Email().Value()] = true
+		}
+	}
+	if !foundEmails[userTestPrefix+"findall1@example.com"] {
+		t.Error("user1が結果に含まれるべき")
+	}
+	if !foundEmails[userTestPrefix+"findall2@example.com"] {
+		t.Error("user2が結果に含まれるべき")
+	}
+}
+
+func TestUserRepository_UpdateRegistrationStatus(t *testing.T) {
+	db := setupDB(t)
+	repo := persistence.NewUserRepository(db)
+
+	user := newTestUser(t, userTestPrefix+"update-status@example.com")
+	t.Cleanup(func() {
+		ctx := context.Background()
+		db.ExecContext(ctx, "DELETE FROM user_registration_requests WHERE user_id = ?", user.ID().Value())
+		db.ExecContext(ctx, "DELETE FROM users WHERE id = ?", user.ID().Value())
+	})
+
+	if err := repo.Save(context.Background(), user); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	approved, err := user.Approve()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if err := repo.UpdateRegistrationStatus(context.Background(), approved); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	found, err := repo.FindByID(context.Background(), user.ID())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if found == nil {
+		t.Fatal("got nil, want non-nil")
+	}
+	if got := found.RegistrationStatus(); got != model.RegistrationStatusApproved {
+		t.Errorf("RegistrationStatus: got %v, want %v", got, model.RegistrationStatusApproved)
+	}
+}
+
+func TestUserRepository_LatestRegistrationStatus(t *testing.T) {
+	db := setupDB(t)
+	repo := persistence.NewUserRepository(db)
+
+	user := newTestUser(t, userTestPrefix+"latest-status@example.com")
+	t.Cleanup(func() {
+		ctx := context.Background()
+		db.ExecContext(ctx, "DELETE FROM user_registration_requests WHERE user_id = ?", user.ID().Value())
+		db.ExecContext(ctx, "DELETE FROM users WHERE id = ?", user.ID().Value())
+	})
+
+	if err := repo.Save(context.Background(), user); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	approved, err := user.Approve()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if err := repo.UpdateRegistrationStatus(context.Background(), approved); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	rejected := model.UserFromRepository(
+		user.ID(),
+		user.Email(),
+		user.Password(),
+		model.RegistrationStatusRejected,
+		user.Role(),
+	)
+	if err := repo.UpdateRegistrationStatus(context.Background(), rejected); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	found, err := repo.FindByID(context.Background(), user.ID())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if found == nil {
+		t.Fatal("got nil, want non-nil")
+	}
+	if got := found.RegistrationStatus(); got != model.RegistrationStatusRejected {
+		t.Errorf("RegistrationStatus: got %v, want %v", got, model.RegistrationStatusRejected)
+	}
+}


### PR DESCRIPTION
## 概要

Go移行 Phase 2（親Issue #190）の一環として、User集約のリポジトリ層を実装しました。Query/Command分離、`user_registration_requests` の履歴方式による最新ステータス取得、`ER_DUP_ENTRY` のドメインエラー変換を含みます。

Closes #205

## 変更内容

- `UserQueryPort`（FindByEmail / FindByID / FindAll）と `UserCommandPort`（Save / UpdateRegistrationStatus）インターフェースを `domain/repository/` に定義
- `UserRepository` アダプタを `infrastructure/persistence/` に実装
  - FindByEmail/FindByID: usersテーブル + `GetLatestRegistrationByUserID`（createdAt DESC LIMIT 1）を組み合わせて最新ステータス付きのドメインUserを構築
  - Save: `WithTx` でトランザクション内に users + user_registration_requests を同時INSERT。`ER_DUP_ENTRY(1062)` を `USER_ALREADY_EXISTS` ドメインエラーに変換
  - UpdateRegistrationStatus: user_registration_requests に新規行をINSERT（履歴追記方式、TS側と同一）
- enum変換は `strings.ToUpper` / `strings.ToLower` でインライン処理

## テスト

- integrationテスト（`//go:build integration`、test-db接続）で9ケースを検証（Save、email重複エラー、FindByEmail存在/不在、FindByID存在/不在、FindAll、UpdateRegistrationStatus、複数登録リクエスト最新取得）

🤖 Generated with [Claude Code](https://claude.com/claude-code)